### PR TITLE
[codex] Add mail index status endpoint

### DIFF
--- a/blocklist-admin/mailops/api.py
+++ b/blocklist-admin/mailops/api.py
@@ -45,6 +45,8 @@ from .api_serializers import (
     LogoutResponseSerializer,
     MailHookRequestSerializer,
     MailHookResponseSerializer,
+    MailIndexStatusQuerySerializer,
+    MailIndexStatusResponseSerializer,
     MessageDetailResponseSerializer,
     MessageSummariesResponseSerializer,
     RestoreMessagesRequestSerializer,
@@ -54,7 +56,7 @@ from .api_serializers import (
     SendMailResponseSerializer,
     UnifiedConversationListResponseSerializer,
 )
-from .models import DeviceRegistration, MailboxTokenCredential
+from .models import DeviceRegistration, MailAccountIndex, MailboxTokenCredential
 from .services import send_mail_notification
 
 
@@ -259,6 +261,26 @@ def account_summary_payload(account_email, summary):
         "display_name": "",
         "unread_count": summary.unread_count,
         "important_count": summary.important_count,
+    }
+
+
+def mail_index_status_payload(index):
+    return {
+        "account_email": index.account_email,
+        "index_status": index.index_status,
+        "last_indexed_at": index.last_indexed_at,
+        "last_sync_started_at": index.last_sync_started_at,
+        "last_sync_finished_at": index.last_sync_finished_at,
+        "last_sync_error": index.last_sync_error,
+        "folders": [
+            {
+                "folder": folder_state.folder,
+                "uidvalidity": folder_state.uidvalidity,
+                "highest_indexed_uid": folder_state.highest_indexed_uid,
+                "last_synced_at": folder_state.last_synced_at,
+            }
+            for folder_state in index.folder_states.order_by("folder")
+        ],
     }
 
 
@@ -598,6 +620,33 @@ class UnifiedConversationListView(APIView):
                 "conversations": [unified_conversation_payload(conversation) for conversation in page.conversations],
             }
         )
+
+
+class MailIndexStatusView(APIView):
+    authentication_classes = MAILBOX_API_AUTHENTICATION_CLASSES
+    permission_classes = MAILBOX_API_PERMISSION_CLASSES
+
+    @extend_schema(
+        operation_id="mail_index_status",
+        parameters=[OpenApiParameter("account_email", str, required=False, description="Mailbox account email. Defaults to the current token mailbox.")],
+        responses={200: MailIndexStatusResponseSerializer, 400: ErrorSerializer, 401: ErrorSerializer, 404: ErrorSerializer},
+    )
+    def get(self, request):
+        credentials, error = require_mailbox_credentials(request)
+        if error:
+            return error
+        serializer = MailIndexStatusQuerySerializer(data=request.query_params)
+        if not serializer.is_valid():
+            return Response({"error": "invalid_account_email"}, status=status.HTTP_400_BAD_REQUEST)
+        account_email = (serializer.validated_data.get("account_email") or credentials.email).strip().lower()
+        index = (
+            MailAccountIndex.objects.filter(user=request.user, account_email=account_email)
+            .prefetch_related("folder_states")
+            .first()
+        )
+        if index is None:
+            return Response({"error": "mail_index_not_found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(mail_index_status_payload(index))
 
 
 class MessageDetailView(APIView):

--- a/blocklist-admin/mailops/api_serializers.py
+++ b/blocklist-admin/mailops/api_serializers.py
@@ -184,6 +184,27 @@ class UnifiedConversationListResponseSerializer(serializers.Serializer):
     conversations = UnifiedConversationSerializer(many=True)
 
 
+class MailIndexStatusQuerySerializer(serializers.Serializer):
+    account_email = serializers.EmailField(required=False)
+
+
+class MailIndexFolderStatusSerializer(serializers.Serializer):
+    folder = serializers.CharField()
+    uidvalidity = serializers.CharField(allow_blank=True)
+    highest_indexed_uid = serializers.IntegerField()
+    last_synced_at = serializers.DateTimeField(allow_null=True)
+
+
+class MailIndexStatusResponseSerializer(serializers.Serializer):
+    account_email = serializers.EmailField()
+    index_status = serializers.CharField()
+    last_indexed_at = serializers.DateTimeField(allow_null=True)
+    last_sync_started_at = serializers.DateTimeField(allow_null=True)
+    last_sync_finished_at = serializers.DateTimeField(allow_null=True)
+    last_sync_error = serializers.CharField(allow_blank=True)
+    folders = MailIndexFolderStatusSerializer(many=True)
+
+
 class MessageDetailResponseSerializer(serializers.Serializer):
     account_email = serializers.EmailField()
     folder = serializers.CharField()

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -733,6 +733,97 @@ class MailApiTests(TestCase):
         self.assertTrue(MailMessageIndex.objects.filter(account=account, uid=101).exists())
         self.assertEqual(touched_thread_keys, set())
 
+    def test_mail_index_status_returns_account_and_folder_state(self):
+        headers = self.auth_headers()
+        token = Token.objects.get(user__email=self.account_email)
+        account = MailAccountIndex.objects.create(
+            user=token.user,
+            account_email=self.account_email,
+            index_status=MailAccountIndex.STATUS_READY,
+            last_indexed_at=datetime(2026, 4, 17, 13, 40, tzinfo=dt_timezone.utc),
+            last_sync_started_at=datetime(2026, 4, 17, 13, 39, 50, tzinfo=dt_timezone.utc),
+            last_sync_finished_at=datetime(2026, 4, 17, 13, 40, tzinfo=dt_timezone.utc),
+            last_sync_error="",
+        )
+        account.folder_states.create(
+            folder="Sent",
+            uidvalidity="67890",
+            highest_indexed_uid=120,
+            last_synced_at=datetime(2026, 4, 17, 13, 39, 58, tzinfo=dt_timezone.utc),
+        )
+        account.folder_states.create(
+            folder="INBOX",
+            uidvalidity="12345",
+            highest_indexed_uid=500,
+            last_synced_at=datetime(2026, 4, 17, 13, 40, tzinfo=dt_timezone.utc),
+        )
+
+        response = self.client.get(reverse("mailops:api_mail_index_status"), **headers)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["account_email"], self.account_email)
+        self.assertEqual(payload["index_status"], MailAccountIndex.STATUS_READY)
+        self.assertEqual(payload["last_sync_error"], "")
+        self.assertIn("2026-04-17T13:40:00", payload["last_indexed_at"])
+        self.assertEqual([folder["folder"] for folder in payload["folders"]], ["INBOX", "Sent"])
+        self.assertEqual(payload["folders"][0]["uidvalidity"], "12345")
+        self.assertEqual(payload["folders"][0]["highest_indexed_uid"], 500)
+
+    def test_mail_index_status_supports_all_statuses_without_folder_rows(self):
+        headers = self.auth_headers()
+        token = Token.objects.get(user__email=self.account_email)
+        statuses = [
+            MailAccountIndex.STATUS_EMPTY,
+            MailAccountIndex.STATUS_SYNCING,
+            MailAccountIndex.STATUS_READY,
+            MailAccountIndex.STATUS_PARTIAL,
+            MailAccountIndex.STATUS_FAILED,
+        ]
+        for index, index_status in enumerate(statuses):
+            email = f"status-{index}@example.com"
+            MailAccountIndex.objects.create(
+                user=token.user,
+                account_email=email,
+                index_status=index_status,
+                last_sync_error="stored operational status" if index_status == MailAccountIndex.STATUS_FAILED else "",
+            )
+
+            response = self.client.get(reverse("mailops:api_mail_index_status"), {"account_email": email}, **headers)
+
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["account_email"], email)
+            self.assertEqual(payload["index_status"], index_status)
+            self.assertEqual(payload["folders"], [])
+            if index_status == MailAccountIndex.STATUS_FAILED:
+                self.assertEqual(payload["last_sync_error"], "stored operational status")
+
+    def test_mail_index_status_requires_token_and_mailbox_credentials(self):
+        missing_token = self.client.get(reverse("mailops:api_mail_index_status"))
+        User = get_user_model()
+        user = User.objects.create_user(username="no-mailbox", email="no-mailbox@example.com")
+        token, _ = Token.objects.get_or_create(user=user)
+
+        missing_credentials = self.client.get(reverse("mailops:api_mail_index_status"), HTTP_AUTHORIZATION=f"Token {token.key}")
+
+        self.assertEqual(missing_token.status_code, 401)
+        self.assertEqual(missing_token.json()["error"], "not_authenticated")
+        self.assertEqual(missing_credentials.status_code, 401)
+        self.assertEqual(missing_credentials.json()["error"], "mailbox_credentials_missing")
+
+    def test_mail_index_status_validates_account_and_returns_not_found(self):
+        headers = self.auth_headers()
+        token = Token.objects.get(user__email=self.account_email)
+        MailAccountIndex.objects.create(user=token.user, account_email=self.account_email)
+        invalid = self.client.get(reverse("mailops:api_mail_index_status"), {"account_email": "not-an-email"}, **headers)
+        missing = self.client.get(reverse("mailops:api_mail_index_status"), {"account_email": "missing@example.com"}, **headers)
+
+        self.assertEqual(invalid.status_code, 400)
+        self.assertEqual(invalid.json()["error"], "invalid_account_email")
+        self.assertEqual(missing.status_code, 404)
+        self.assertEqual(missing.json()["error"], "mail_index_not_found")
+
     def test_mail_index_sync_runner_selects_due_accounts_and_skips_fresh_or_active_syncing(self):
         token = create_mailbox_token(self.account_email, self.password)
         now = timezone.now()
@@ -1488,6 +1579,7 @@ class MailApiTests(TestCase):
         self.assertContains(schema, "/api/mail/messages/{uid}/attachments/{attachment_id}")
         self.assertContains(schema, "/api/mail/conversations")
         self.assertContains(schema, "/api/mail/unified-conversations")
+        self.assertContains(schema, "/api/mail/index-status")
         self.assertContains(schema, "/api/mail/send")
         self.assertContains(schema, "/api/devices/")
         self.assertContains(schema, "/api/accounts/summaries")

--- a/blocklist-admin/mailops/urls.py
+++ b/blocklist-admin/mailops/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("api/mail/folders", api.FolderListView.as_view(), name="api_mail_folders"),
     path("api/mail/conversations", api.ConversationListView.as_view(), name="api_mail_conversations"),
     path("api/mail/unified-conversations", api.UnifiedConversationListView.as_view(), name="api_mail_unified_conversations"),
+    path("api/mail/index-status", api.MailIndexStatusView.as_view(), name="api_mail_index_status"),
     path("api/mail/messages", api.MessageListView.as_view(), name="api_mail_messages"),
     path("api/mail/messages/delete", api.DeleteMessagesView.as_view(), name="api_mail_messages_delete"),
     path("api/mail/messages/restore", api.RestoreMessagesView.as_view(), name="api_mail_messages_restore"),

--- a/docs/mailbox-api.md
+++ b/docs/mailbox-api.md
@@ -351,6 +351,33 @@ In Docker, the `mailindex-sync` service runs this loop. It selects stale indexed
 
 Incremental sync refreshes newer UIDs plus a recent metadata window. It does not delete indexed rows that are missing from that recent window unless `MAIL_INDEX_RECONCILE_DELETIONS=true` is explicitly enabled, because deletion reconciliation depends on the IMAP server returning a complete and trustworthy UID view for that checked window.
 
+`GET /api/mail/index-status`
+
+Returns the stored Django mail index status for the authenticated mailbox. The endpoint is read-only, requires the same mailbox token context as the other mailbox APIs, and never triggers sync or live IMAP calls. Optional query parameter: `account_email`; when omitted, the current token mailbox is used.
+
+Response:
+
+```json
+{
+  "account_email": "user@finestar.hr",
+  "index_status": "ready",
+  "last_indexed_at": "2026-04-17T13:40:00Z",
+  "last_sync_started_at": "2026-04-17T13:39:50Z",
+  "last_sync_finished_at": "2026-04-17T13:40:00Z",
+  "last_sync_error": "",
+  "folders": [
+    {
+      "folder": "INBOX",
+      "uidvalidity": "12345",
+      "highest_indexed_uid": 500,
+      "last_synced_at": "2026-04-17T13:40:00Z"
+    }
+  ]
+}
+```
+
+If the authenticated user has no index row for the requested mailbox, the endpoint returns `404 {"error": "mail_index_not_found"}`. Invalid `account_email` returns `400 {"error": "invalid_account_email"}`. `last_sync_error` is returned as stored operational status only; sync code must not write credentials, raw message bodies, or raw MIME content into that field.
+
 `GET /api/mail/messages/42?folder=INBOX`
 
 Response:


### PR DESCRIPTION
## Summary
- Adds `GET /api/mail/index-status` for read-only mail index observability.
- Returns account-level `MailAccountIndex` status/timestamps/error plus folder-level `MailFolderIndexState` rows.
- Keeps auth behavior consistent with mailbox APIs via `require_mailbox_credentials(request)`.
- Documents that `last_sync_error` is returned as stored operational status and must not contain credentials or raw content.

## Validation
- docker compose build mailadmin
- docker compose run --rm mailadmin python manage.py check
- docker compose run --rm mailadmin python manage.py makemigrations --check --dry-run
- docker compose run --rm mailadmin python manage.py test
- docker compose up -d mailadmin mailindex-sync
- smoke: GET /api/mail/index-status for app-test-2@finestar.hr returned ready status and folder state

## Notes
- No migration required.
- Endpoint is read-only and does not trigger sync or live IMAP calls.
