### PR TITLE
[codex] Add Gmail OAuth bootstrap client

### DIFF
--- a/blocklist-admin/mail_integration/gmail_client.py
+++ b/blocklist-admin/mail_integration/gmail_client.py
@@ -1,0 +1,305 @@
+import base64
+import random
+import time
+from dataclasses import dataclass, field
+from email import policy
+from email.parser import BytesParser
+
+from django.conf import settings
+
+from .exceptions import MailAuthError, MailConnectionError, MailProtocolError
+
+
+GMAIL_USER_ID = "me"
+DEFAULT_RETRY_STATUSES = {429, 500, 502, 503, 504}
+
+
+@dataclass(frozen=True)
+class GmailOAuthConfig:
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    scopes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GmailMessageRef:
+    gmail_message_id: str
+    gmail_thread_id: str = ""
+    history_id: str = ""
+    label_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class GmailRawMessage:
+    gmail_message_id: str
+    gmail_thread_id: str
+    history_id: str
+    label_ids: tuple[str, ...]
+    raw_bytes: bytes
+    rfc_message_id: str = ""
+
+
+@dataclass(frozen=True)
+class GmailHistoryMessage:
+    gmail_message_id: str
+    gmail_thread_id: str = ""
+    history_id: str = ""
+    label_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class GmailHistoryPage:
+    history_id: str
+    messages_added: tuple[GmailHistoryMessage, ...] = field(default_factory=tuple)
+    next_page_token: str = ""
+
+
+class GmailClient:
+    def __init__(
+        self,
+        refresh_token,
+        oauth_config=None,
+        service=None,
+        sleep=time.sleep,
+        max_retries=3,
+        initial_backoff_seconds=1,
+    ):
+        self.refresh_token = refresh_token
+        self.oauth_config = oauth_config
+        self._service = service
+        self.sleep = sleep
+        self.max_retries = int(max_retries)
+        self.initial_backoff_seconds = float(initial_backoff_seconds)
+
+    @property
+    def service(self):
+        if self._service is None:
+            self._service = build_gmail_service(self.oauth_config or oauth_config_from_settings(), self.refresh_token)
+        return self._service
+
+    def list_message_refs(self, query="", max_results=100, page_token=""):
+        request = self.service.users().messages().list(
+            userId=GMAIL_USER_ID,
+            q=query or None,
+            maxResults=max_results,
+            pageToken=page_token or None,
+        )
+        payload = self._execute(request, "Gmail message listing failed")
+        refs = tuple(
+            GmailMessageRef(
+                gmail_message_id=str(item.get("id", "")),
+                gmail_thread_id=str(item.get("threadId", "")),
+            )
+            for item in payload.get("messages", ())
+            if item.get("id")
+        )
+        return refs, str(payload.get("nextPageToken", "") or "")
+
+    def fetch_raw_message(self, gmail_message_id):
+        request = self.service.users().messages().get(userId=GMAIL_USER_ID, id=gmail_message_id, format="raw")
+        payload = self._execute(request, f"Gmail message fetch failed for {gmail_message_id}")
+        raw = payload.get("raw", "")
+        if not raw:
+            raise MailProtocolError(f"Gmail message {gmail_message_id} did not include a raw payload")
+        raw_bytes = _urlsafe_b64decode(raw)
+        return GmailRawMessage(
+            gmail_message_id=str(payload.get("id", gmail_message_id)),
+            gmail_thread_id=str(payload.get("threadId", "")),
+            history_id=str(payload.get("historyId", "")),
+            label_ids=tuple(str(label) for label in payload.get("labelIds", ()) if label),
+            raw_bytes=raw_bytes,
+            rfc_message_id=_rfc_message_id(raw_bytes),
+        )
+
+    def list_history_page(self, start_history_id, page_token=""):
+        request = self.service.users().history().list(
+            userId=GMAIL_USER_ID,
+            startHistoryId=str(start_history_id),
+            historyTypes=["messageAdded"],
+            pageToken=page_token or None,
+        )
+        payload = self._execute(request, f"Gmail history listing failed from {start_history_id}")
+        messages = []
+        for item in payload.get("history", ()):
+            history_id = str(item.get("id", "") or "")
+            for added in item.get("messagesAdded", ()):
+                message = added.get("message", {})
+                gmail_message_id = str(message.get("id", "") or "")
+                if not gmail_message_id:
+                    continue
+                messages.append(
+                    GmailHistoryMessage(
+                        gmail_message_id=gmail_message_id,
+                        gmail_thread_id=str(message.get("threadId", "") or ""),
+                        history_id=history_id,
+                        label_ids=tuple(str(label) for label in message.get("labelIds", ()) if label),
+                    )
+                )
+        return GmailHistoryPage(
+            history_id=str(payload.get("historyId", "") or ""),
+            messages_added=tuple(messages),
+            next_page_token=str(payload.get("nextPageToken", "") or ""),
+        )
+
+    def delete_message(self, gmail_message_id):
+        request = self.service.users().messages().delete(userId=GMAIL_USER_ID, id=gmail_message_id)
+        self._execute(request, f"Gmail message delete failed for {gmail_message_id}")
+
+    def _execute(self, request, error_message):
+        return execute_with_retry(
+            request,
+            error_message=error_message,
+            sleep=self.sleep,
+            max_retries=self.max_retries,
+            initial_backoff_seconds=self.initial_backoff_seconds,
+        )
+
+
+def oauth_config_from_settings():
+    config = GmailOAuthConfig(
+        client_id=getattr(settings, "GMAIL_IMPORT_GOOGLE_CLIENT_ID", ""),
+        client_secret=getattr(settings, "GMAIL_IMPORT_GOOGLE_CLIENT_SECRET", ""),
+        redirect_uri=getattr(settings, "GMAIL_IMPORT_OAUTH_REDIRECT_URI", ""),
+        scopes=tuple(getattr(settings, "GMAIL_IMPORT_OAUTH_SCOPES", ())),
+    )
+    if not config.client_id:
+        raise MailProtocolError("GMAIL_IMPORT_GOOGLE_CLIENT_ID is required")
+    if not config.client_secret:
+        raise MailProtocolError("GMAIL_IMPORT_GOOGLE_CLIENT_SECRET is required")
+    if not config.redirect_uri:
+        raise MailProtocolError("GMAIL_IMPORT_OAUTH_REDIRECT_URI is required")
+    if not config.scopes:
+        raise MailProtocolError("GMAIL_IMPORT_OAUTH_SCOPES must include at least one scope")
+    return config
+
+
+def build_authorization_url(oauth_config=None, state=""):
+    flow = _oauth_flow(oauth_config or oauth_config_from_settings())
+    authorization_url, _ = flow.authorization_url(
+        access_type="offline",
+        include_granted_scopes="true",
+        prompt="consent",
+        state=state or None,
+    )
+    return authorization_url
+
+
+def exchange_code_for_refresh_token(code, oauth_config=None):
+    if not str(code or "").strip():
+        raise MailProtocolError("OAuth authorization code is required")
+    flow = _oauth_flow(oauth_config or oauth_config_from_settings())
+    try:
+        flow.fetch_token(code=str(code).strip())
+    except Exception as exc:
+        if _is_google_auth_error(exc):
+            raise MailAuthError("Gmail OAuth token exchange failed") from exc
+        raise
+    refresh_token = getattr(flow.credentials, "refresh_token", "")
+    if not refresh_token:
+        raise MailAuthError("Gmail OAuth token exchange did not return a refresh token")
+    return refresh_token
+
+
+def build_gmail_service(oauth_config, refresh_token):
+    if not str(refresh_token or "").strip():
+        raise MailAuthError("Gmail refresh token is required")
+    Credentials, build = _google_service_dependencies()
+    credentials = Credentials(
+        token=None,
+        refresh_token=refresh_token,
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id=oauth_config.client_id,
+        client_secret=oauth_config.client_secret,
+        scopes=oauth_config.scopes,
+    )
+    return build("gmail", "v1", credentials=credentials, cache_discovery=False)
+
+
+def execute_with_retry(request, error_message, sleep=time.sleep, max_retries=3, initial_backoff_seconds=1):
+    attempts = int(max_retries) + 1
+    for attempt in range(attempts):
+        try:
+            return request.execute()
+        except Exception as exc:
+            status = _http_error_status(exc)
+            if status == 401:
+                raise MailAuthError(f"{error_message}: authentication failed") from exc
+            if status == 403:
+                raise MailAuthError(f"{error_message}: permission denied") from exc
+            retryable = status in DEFAULT_RETRY_STATUSES
+            if not retryable or attempt >= attempts - 1:
+                if status:
+                    raise MailConnectionError(f"{error_message}: Gmail API returned HTTP {status}") from exc
+                raise MailConnectionError(f"{error_message}: {exc}") from exc
+            sleep(_retry_delay(initial_backoff_seconds, attempt))
+    raise MailConnectionError(error_message)
+
+
+def _oauth_flow(oauth_config):
+    Flow = _oauth_flow_dependency()
+    config = {
+        "web": {
+            "client_id": oauth_config.client_id,
+            "client_secret": oauth_config.client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": [oauth_config.redirect_uri],
+        }
+    }
+    return Flow.from_client_config(config, scopes=oauth_config.scopes, redirect_uri=oauth_config.redirect_uri)
+
+
+def _oauth_flow_dependency():
+    try:
+        from google_auth_oauthlib.flow import Flow
+    except ImportError as exc:
+        raise MailProtocolError("google-auth-oauthlib is required for Gmail OAuth") from exc
+    return Flow
+
+
+def _google_service_dependencies():
+    try:
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+    except ImportError as exc:
+        raise MailProtocolError("google-api-python-client and google-auth are required for Gmail API access") from exc
+    return Credentials, build
+
+
+def _http_error_status(exc):
+    response = getattr(exc, "resp", None)
+    status = getattr(response, "status", None)
+    try:
+        return int(status) if status else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_google_auth_error(exc):
+    try:
+        from google.auth.exceptions import GoogleAuthError
+    except ImportError:
+        return False
+    return isinstance(exc, GoogleAuthError)
+
+
+def _retry_delay(initial_backoff_seconds, attempt):
+    return float(initial_backoff_seconds) * (2**attempt) + random.uniform(0, 0.1)
+
+
+def _urlsafe_b64decode(value):
+    payload = str(value).encode("ascii")
+    payload += b"=" * (-len(payload) % 4)
+    try:
+        return base64.urlsafe_b64decode(payload)
+    except (ValueError, TypeError) as exc:
+        raise MailProtocolError("Gmail raw payload is not valid base64url data") from exc
+
+
+def _rfc_message_id(raw_bytes):
+    try:
+        message = BytesParser(policy=policy.default).parsebytes(raw_bytes)
+        return str(message.get("message-id", "") or "")
+    except Exception:
+        return ""

--- a/blocklist-admin/mail_integration/tests.py
+++ b/blocklist-admin/mail_integration/tests.py
@@ -1,4 +1,5 @@
 import imaplib
+import base64
 import socket
 import smtplib
 import ssl
@@ -19,6 +20,7 @@ from .exceptions import (
     MailTimeoutError,
 )
 from .imap_client import ImapClient
+from .gmail_client import GmailClient, execute_with_retry, oauth_config_from_settings
 from .mailbox_service import MailboxService
 from .schemas import (
     ForwardSourceMessage,
@@ -34,6 +36,134 @@ from .schemas import (
     SendMailRequest,
 )
 from .smtp_client import SmtpClient, build_email_message
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def execute(self):
+        return self.payload
+
+
+class _FakeHttpError(Exception):
+    def __init__(self, status):
+        super().__init__(f"HTTP {status}")
+        self.resp = Mock(status=status)
+
+
+def _http_error(status):
+    return _FakeHttpError(status)
+
+
+def _gmail_service(list_payload=None, get_payload=None, history_payload=None, delete_payload=None):
+    service = Mock()
+    users_api = Mock()
+    messages_api = Mock()
+    history_api = Mock()
+    service.users_api = users_api
+    users_api.messages_api = messages_api
+    users_api.history_api = history_api
+    service.users.return_value = users_api
+    users_api.messages.return_value = messages_api
+    users_api.history.return_value = history_api
+    messages_api.list.return_value = _FakeRequest(list_payload or {})
+    messages_api.get.return_value = _FakeRequest(get_payload or {})
+    messages_api.delete.return_value = _FakeRequest(delete_payload or {})
+    history_api.list.return_value = _FakeRequest(history_payload or {})
+    return service
+
+
+class GmailClientTests(SimpleTestCase):
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="urn:ietf:wg:oauth:2.0:oob",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+    )
+    def test_oauth_config_reads_settings(self):
+        config = oauth_config_from_settings()
+
+        self.assertEqual(config.client_id, "client-id")
+        self.assertEqual(config.client_secret, "client-secret")
+        self.assertEqual(config.scopes, ("https://www.googleapis.com/auth/gmail.modify",))
+
+    def test_fetch_raw_message_decodes_payload_and_metadata(self):
+        raw_bytes = b"Message-ID: <gmail-msg@example.com>\r\nSubject: Hi\r\n\r\nBody"
+        raw_payload = base64.urlsafe_b64encode(raw_bytes).decode("ascii").rstrip("=")
+        service = _gmail_service(
+            get_payload={
+                "id": "msg-1",
+                "threadId": "thread-1",
+                "historyId": "17",
+                "labelIds": ["INBOX"],
+                "raw": raw_payload,
+            }
+        )
+
+        message = GmailClient(refresh_token="refresh", service=service).fetch_raw_message("msg-1")
+
+        self.assertEqual(message.gmail_message_id, "msg-1")
+        self.assertEqual(message.gmail_thread_id, "thread-1")
+        self.assertEqual(message.history_id, "17")
+        self.assertEqual(message.label_ids, ("INBOX",))
+        self.assertEqual(message.raw_bytes, raw_bytes)
+        self.assertEqual(message.rfc_message_id, "<gmail-msg@example.com>")
+
+    def test_list_message_refs_and_history_messages(self):
+        service = _gmail_service(
+            list_payload={"messages": [{"id": "msg-1", "threadId": "thread-1"}], "nextPageToken": "next"},
+            history_payload={
+                "historyId": "99",
+                "history": [
+                    {
+                        "id": "98",
+                        "messagesAdded": [
+                            {"message": {"id": "msg-2", "threadId": "thread-2", "labelIds": ["SENT"]}},
+                        ],
+                    }
+                ],
+            },
+        )
+        client = GmailClient(refresh_token="refresh", service=service)
+
+        refs, next_page = client.list_message_refs(query="-in:spam", max_results=10)
+        history = client.list_history_page(start_history_id="97")
+
+        self.assertEqual(refs[0].gmail_message_id, "msg-1")
+        self.assertEqual(next_page, "next")
+        self.assertEqual(history.history_id, "99")
+        self.assertEqual(history.messages_added[0].gmail_message_id, "msg-2")
+        self.assertEqual(history.messages_added[0].label_ids, ("SENT",))
+
+    def test_delete_message_executes_delete_request(self):
+        service = _gmail_service(delete_payload={})
+
+        GmailClient(refresh_token="refresh", service=service).delete_message("msg-1")
+
+        service.users_api.messages_api.delete.assert_called_once_with(userId="me", id="msg-1")
+
+    def test_execute_with_retry_retries_429_then_succeeds(self):
+        request = Mock()
+        request.execute.side_effect = [_http_error(429), {"ok": True}]
+        sleep = Mock()
+
+        result = execute_with_retry(request, "Gmail failed", sleep=sleep, initial_backoff_seconds=0)
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(request.execute.call_count, 2)
+        sleep.assert_called_once()
+
+    def test_execute_with_retry_maps_auth_and_non_retryable_errors(self):
+        auth_request = Mock()
+        auth_request.execute.side_effect = _http_error(401)
+        bad_request = Mock()
+        bad_request.execute.side_effect = _http_error(400)
+
+        with self.assertRaises(MailAuthError):
+            execute_with_retry(auth_request, "Gmail failed", sleep=Mock())
+        with self.assertRaises(MailConnectionError):
+            execute_with_retry(bad_request, "Gmail failed", sleep=Mock())
 
 
 @override_settings(

--- a/blocklist-admin/mailops/management/commands/bootstrap_gmail_import_oauth.py
+++ b/blocklist-admin/mailops/management/commands/bootstrap_gmail_import_oauth.py
@@ -1,0 +1,59 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from mail_integration.exceptions import MailAuthError, MailIntegrationError
+from mail_integration.gmail_client import build_authorization_url, exchange_code_for_refresh_token, oauth_config_from_settings
+
+from mailops.models import GmailImportAccount
+
+
+class Command(BaseCommand):
+    help = "Bootstrap OAuth credentials for one Gmail import account."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--gmail", required=True, help="Source Gmail address to import from.")
+        parser.add_argument("--target", required=True, help="Target mailserver mailbox email.")
+        parser.add_argument("--code", default="", help="OAuth authorization code returned by Google.")
+        parser.add_argument("--state", default="", help="Optional OAuth state value for the consent URL.")
+
+    def handle(self, *args, **options):
+        gmail_email = _normalize_email(options["gmail"], "--gmail")
+        target_mailbox_email = _normalize_email(options["target"], "--target")
+        code = str(options.get("code") or "").strip()
+
+        try:
+            oauth_config = oauth_config_from_settings()
+        except MailIntegrationError as exc:
+            raise CommandError(str(exc)) from exc
+
+        if not code:
+            self.stdout.write("Open this URL to authorize Gmail import access:")
+            self.stdout.write(build_authorization_url(oauth_config, state=str(options.get("state") or "").strip()))
+            self.stdout.write("")
+            self.stdout.write("Then rerun this command with --code <authorization-code>.")
+            return
+
+        try:
+            refresh_token = exchange_code_for_refresh_token(code, oauth_config)
+        except MailAuthError as exc:
+            raise CommandError(str(exc)) from exc
+        except MailIntegrationError as exc:
+            raise CommandError(str(exc)) from exc
+
+        account = GmailImportAccount.objects.filter(gmail_email=gmail_email).first()
+        created = account is None
+        if account is None:
+            account = GmailImportAccount(gmail_email=gmail_email, target_mailbox_email=target_mailbox_email)
+        account.target_mailbox_email = target_mailbox_email
+        account.set_refresh_token(refresh_token)
+        account.last_error = ""
+        account.save()
+
+        action = "Created" if created else "Updated"
+        self.stdout.write(self.style.SUCCESS(f"{action} Gmail import account: {gmail_email} -> {target_mailbox_email}"))
+
+
+def _normalize_email(value, option_name):
+    email = str(value or "").strip().lower()
+    if not email or "@" not in email:
+        raise CommandError(f"{option_name} must be a valid email address")
+    return email

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -472,6 +472,59 @@ class MailApiTests(TestCase):
         self.assertIn("refresh_token", account_admin.exclude)
         self.assertIn("refresh_token_status", account_admin.readonly_fields)
 
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="urn:ietf:wg:oauth:2.0:oob",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+    )
+    @patch("mailops.management.commands.bootstrap_gmail_import_oauth.build_authorization_url", return_value="https://accounts.google.test/auth")
+    def test_gmail_oauth_bootstrap_prints_consent_url_without_code(self, build_authorization_url):
+        stdout = io.StringIO()
+
+        call_command(
+            "bootstrap_gmail_import_oauth",
+            "--gmail",
+            "source@gmail.com",
+            "--target",
+            "target@example.com",
+            stdout=stdout,
+        )
+
+        self.assertIn("https://accounts.google.test/auth", stdout.getvalue())
+        self.assertEqual(GmailImportAccount.objects.count(), 0)
+        build_authorization_url.assert_called_once()
+
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="urn:ietf:wg:oauth:2.0:oob",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+    )
+    @patch("mailops.management.commands.bootstrap_gmail_import_oauth.exchange_code_for_refresh_token", return_value="refresh-secret")
+    def test_gmail_oauth_bootstrap_stores_encrypted_refresh_token(self, exchange_code):
+        stdout = io.StringIO()
+
+        call_command(
+            "bootstrap_gmail_import_oauth",
+            "--gmail",
+            " SOURCE@Gmail.COM ",
+            "--target",
+            " TARGET@Example.COM ",
+            "--code",
+            "auth-code",
+            stdout=stdout,
+        )
+
+        account = GmailImportAccount.objects.get()
+        self.assertEqual(account.gmail_email, "source@gmail.com")
+        self.assertEqual(account.target_mailbox_email, "target@example.com")
+        self.assertTrue(account.refresh_token.startswith(ENCRYPTED_VALUE_PREFIX))
+        self.assertNotIn("refresh-secret", account.refresh_token)
+        self.assertEqual(account.get_refresh_token(), "refresh-secret")
+        self.assertIn("Created Gmail import account", stdout.getvalue())
+        exchange_code.assert_called_once()
+
     def test_legacy_plaintext_migration_encrypts_existing_rows(self):
         migration = importlib.import_module("mailops.migrations.0004_encrypt_mailbox_token_credentials")
         user = get_user_model().objects.create_user(username="legacy@example.com", email="legacy@example.com")


### PR DESCRIPTION
## Summary
- add a Gmail API client wrapper for OAuth-backed Gmail import work
- add OAuth consent URL generation and authorization-code exchange helpers
- add `bootstrap_gmail_import_oauth` management command to store encrypted Gmail refresh tokens
- cover Gmail API list/fetch/history/delete, retry/backoff, OAuth bootstrap, and encrypted token persistence with tests

## Notes
This is PR 2 from issue #20. It builds on the merged Gmail import foundation from PR #21 and intentionally does not implement historical import, target IMAP append, Gmail cleanup, or periodic sync yet.

The Gmail client uses lazy Google dependency imports so the existing Django app can still load before the Docker image is rebuilt with the PR #21 dependency additions.

## Validation
- `docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mail_integration mailops`
- `docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py check`

Part of #20.
