### PR TITLE
[codex] Add Gmail historical import command

### DIFF
--- a/blocklist-admin/mailops/gmail_import.py
+++ b/blocklist-admin/mailops/gmail_import.py
@@ -1,0 +1,285 @@
+from dataclasses import dataclass
+
+from django.utils import timezone
+
+from mail_integration.gmail_client import GmailClient
+from mail_integration.imap_client import ImapClient
+from mail_integration.schemas import MailboxCredentials
+
+from .models import GmailImportAccount, GmailImportMessage, GmailImportRun, MailAccountIndex, MailboxTokenCredential
+
+
+GMAIL_HISTORICAL_QUERY = "in:anywhere -in:drafts -in:spam -in:trash"
+GMAIL_SENT_LABEL = "SENT"
+DEFAULT_TARGET_FOLDER = "INBOX"
+
+
+@dataclass(frozen=True)
+class GmailImportResult:
+    run: GmailImportRun | None
+    scanned: int
+    appended: int
+    committed: int
+    cleaned: int
+    skipped: int
+    failed: int
+
+
+class GmailImportError(Exception):
+    pass
+
+
+class GmailImportService:
+    def __init__(self, gmail_client_factory=None, imap_client_factory=ImapClient):
+        self.gmail_client_factory = gmail_client_factory or (lambda refresh_token: GmailClient(refresh_token=refresh_token))
+        self.imap_client_factory = imap_client_factory
+
+    def run_historical_import(self, gmail_email, target_mailbox_email, limit=100, since="", dry_run=False, no_delete=False):
+        gmail_email = _normalize_email(gmail_email)
+        target_mailbox_email = _normalize_email(target_mailbox_email)
+        limit = int(limit)
+        if limit < 1:
+            raise GmailImportError("--limit must be greater than zero")
+
+        import_account = self._get_import_account(gmail_email, target_mailbox_email)
+        run = None if dry_run else GmailImportRun.objects.create(import_account=import_account, mode=GmailImportRun.MODE_HISTORICAL)
+
+        try:
+            result = self._run_historical_batch(
+                import_account=import_account,
+                target_mailbox_email=target_mailbox_email,
+                run=run,
+                limit=limit,
+                since=since,
+                dry_run=dry_run,
+                no_delete=no_delete,
+            )
+        except Exception as exc:
+            if run is not None:
+                run.status = GmailImportRun.STATUS_FAILED
+                run.error = str(exc)[:2000]
+                run.finished_at = timezone.now()
+                run.save(update_fields=["status", "error", "finished_at"])
+            import_account.consecutive_failures += 1
+            import_account.last_error = str(exc)[:2000]
+            import_account.save(update_fields=["consecutive_failures", "last_error", "updated_at"])
+            raise
+
+        if run is not None:
+            run.status = GmailImportRun.STATUS_SUCCESS if result.failed == 0 else GmailImportRun.STATUS_PARTIAL
+            run.scanned_count = result.scanned
+            run.appended_count = result.appended
+            run.committed_count = result.committed
+            run.cleaned_count = result.cleaned
+            run.skipped_count = result.skipped
+            run.failed_count = result.failed
+            run.finished_at = timezone.now()
+            run.save(
+                update_fields=[
+                    "status",
+                    "scanned_count",
+                    "appended_count",
+                    "committed_count",
+                    "cleaned_count",
+                    "skipped_count",
+                    "failed_count",
+                    "finished_at",
+                ]
+            )
+
+        if dry_run:
+            return result
+
+        if result.failed == 0:
+            import_account.consecutive_failures = 0
+            import_account.last_error = ""
+            import_account.last_success_at = run.finished_at if run is not None else timezone.now()
+            update_fields = ["consecutive_failures", "last_error", "last_success_at", "updated_at"]
+            if not import_account.historical_import_completed_at:
+                import_account.historical_import_completed_at = import_account.last_success_at
+                update_fields.append("historical_import_completed_at")
+            import_account.save(update_fields=update_fields)
+        elif result.committed:
+            import_account.last_error = f"{result.failed} Gmail import message(s) failed"
+            import_account.save(update_fields=["last_error", "updated_at"])
+
+        return result
+
+    def _run_historical_batch(self, import_account, target_mailbox_email, run, limit, since, dry_run, no_delete):
+        gmail_client = self.gmail_client_factory(import_account.get_refresh_token())
+        refs = _bounded_refs(gmail_client, query=_historical_query(since), limit=limit)
+        scanned = len(refs)
+        if dry_run:
+            return self._dry_run_result(run, scanned=scanned)
+
+        target_credentials = self._target_credentials(target_mailbox_email)
+        appended = committed = cleaned = skipped = failed = 0
+        any_committed = False
+        cleanup_enabled = bool(import_account.delete_after_import and not no_delete)
+
+        with self.imap_client_factory() as imap_client:
+            imap_client.login(target_credentials)
+            sent_folder = imap_client._resolve_sent_folder()
+            for ref in refs:
+                message_record = self._get_or_create_message_record(import_account, ref)
+                if message_record.state == GmailImportMessage.STATE_CLEANED:
+                    skipped += 1
+                    continue
+                if message_record.state == GmailImportMessage.STATE_COMMITTED:
+                    skipped += 1
+                    if cleanup_enabled and message_record.cleanup_status != GmailImportMessage.STATUS_SUCCESS:
+                        if self._try_clean_gmail_source(gmail_client, message_record):
+                            cleaned += 1
+                        else:
+                            failed += 1
+                    continue
+                if message_record.state == GmailImportMessage.STATE_APPENDED and message_record.append_status == GmailImportMessage.STATUS_SUCCESS:
+                    self._mark_committed(message_record)
+                    committed += 1
+                    any_committed = True
+                    if cleanup_enabled:
+                        if self._try_clean_gmail_source(gmail_client, message_record):
+                            cleaned += 1
+                        else:
+                            failed += 1
+                    continue
+
+                try:
+                    raw_message = gmail_client.fetch_raw_message(ref.gmail_message_id)
+                    target_folder = _target_folder(raw_message.label_ids, sent_folder)
+                    self._mark_fetched(message_record, raw_message)
+                    imap_client.append_message(target_folder, raw_message.raw_bytes)
+                    self._mark_appended(message_record, target_folder)
+                    appended += 1
+                    self._mark_committed(message_record)
+                    committed += 1
+                    any_committed = True
+                    if cleanup_enabled:
+                        if self._try_clean_gmail_source(gmail_client, message_record):
+                            cleaned += 1
+                        else:
+                            failed += 1
+                except Exception as exc:
+                    failed += 1
+                    self._mark_failed(message_record, exc)
+
+        if any_committed:
+            self._mark_index_stale(target_mailbox_email)
+
+        return GmailImportResult(run=run, scanned=scanned, appended=appended, committed=committed, cleaned=cleaned, skipped=skipped, failed=failed)
+
+    def _dry_run_result(self, run, scanned):
+        return GmailImportResult(run=run, scanned=scanned, appended=0, committed=0, cleaned=0, skipped=0, failed=0)
+
+    def _get_import_account(self, gmail_email, target_mailbox_email):
+        try:
+            account = GmailImportAccount.objects.get(gmail_email=gmail_email)
+        except GmailImportAccount.DoesNotExist as exc:
+            raise GmailImportError(f"No Gmail import account configured for {gmail_email}. Run bootstrap_gmail_import_oauth first.") from exc
+        if account.target_mailbox_email != target_mailbox_email:
+            raise GmailImportError(f"Gmail import account {gmail_email} is mapped to {account.target_mailbox_email}, not {target_mailbox_email}.")
+        return account
+
+    def _target_credentials(self, target_mailbox_email):
+        try:
+            credential = MailboxTokenCredential.objects.select_related("token__user").get(mailbox_email=target_mailbox_email)
+        except MailboxTokenCredential.DoesNotExist as exc:
+            raise GmailImportError(f"No mailbox token credential found for target mailbox {target_mailbox_email}") from exc
+        return MailboxCredentials(email=credential.mailbox_email, password=credential.get_mailbox_password())
+
+    def _get_or_create_message_record(self, import_account, ref):
+        record, _ = GmailImportMessage.objects.get_or_create(
+            import_account=import_account,
+            gmail_message_id=ref.gmail_message_id,
+            defaults={
+                "gmail_thread_id": ref.gmail_thread_id,
+                "state": GmailImportMessage.STATE_FETCHED,
+                "fetched_at": timezone.now(),
+            },
+        )
+        return record
+
+    def _mark_fetched(self, record, raw_message):
+        record.gmail_thread_id = raw_message.gmail_thread_id or record.gmail_thread_id
+        record.rfc_message_id = raw_message.rfc_message_id
+        record.state = GmailImportMessage.STATE_FETCHED
+        record.fetched_at = timezone.now()
+        record.error = ""
+        record.save(update_fields=["gmail_thread_id", "rfc_message_id", "state", "fetched_at", "error", "updated_at"])
+
+    def _mark_appended(self, record, target_folder):
+        record.target_folder = target_folder
+        record.state = GmailImportMessage.STATE_APPENDED
+        record.append_status = GmailImportMessage.STATUS_SUCCESS
+        record.appended_at = timezone.now()
+        record.error = ""
+        record.save(update_fields=["target_folder", "state", "append_status", "appended_at", "error", "updated_at"])
+
+    def _mark_committed(self, record):
+        record.state = GmailImportMessage.STATE_COMMITTED
+        record.committed_at = record.committed_at or timezone.now()
+        record.error = ""
+        record.save(update_fields=["state", "committed_at", "error", "updated_at"])
+
+    def _clean_gmail_source(self, gmail_client, record):
+        gmail_client.delete_message(record.gmail_message_id)
+        record.state = GmailImportMessage.STATE_CLEANED
+        record.cleanup_status = GmailImportMessage.STATUS_SUCCESS
+        record.cleaned_at = timezone.now()
+        record.error = ""
+        record.save(update_fields=["state", "cleanup_status", "cleaned_at", "error", "updated_at"])
+        return True
+
+    def _try_clean_gmail_source(self, gmail_client, record):
+        try:
+            return self._clean_gmail_source(gmail_client, record)
+        except Exception as exc:
+            self._mark_cleanup_failed(record, exc)
+            return False
+
+    def _mark_failed(self, record, exc):
+        record.state = GmailImportMessage.STATE_FAILED
+        record.error = str(exc)[:2000]
+        if record.append_status != GmailImportMessage.STATUS_SUCCESS:
+            record.append_status = GmailImportMessage.STATUS_FAILED
+        record.save(update_fields=["state", "append_status", "error", "updated_at"])
+
+    def _mark_cleanup_failed(self, record, exc):
+        record.state = GmailImportMessage.STATE_COMMITTED
+        record.cleanup_status = GmailImportMessage.STATUS_FAILED
+        record.error = str(exc)[:2000]
+        record.save(update_fields=["state", "cleanup_status", "error", "updated_at"])
+
+    def _mark_index_stale(self, target_mailbox_email):
+        MailAccountIndex.objects.filter(account_email=target_mailbox_email).update(last_indexed_at=None)
+
+
+def _bounded_refs(gmail_client, query, limit):
+    refs = []
+    page_token = ""
+    while len(refs) < limit:
+        page_limit = min(100, limit - len(refs))
+        page_refs, page_token = gmail_client.list_message_refs(query=query, max_results=page_limit, page_token=page_token)
+        refs.extend(page_refs)
+        if not page_token or not page_refs:
+            break
+    return tuple(refs[:limit])
+
+
+def _historical_query(since):
+    query = GMAIL_HISTORICAL_QUERY
+    since = str(since or "").strip()
+    if since:
+        query = f"{query} after:{since}"
+    return query
+
+
+def _target_folder(label_ids, sent_folder):
+    normalized_labels = {str(label).upper() for label in label_ids or ()}
+    if GMAIL_SENT_LABEL in normalized_labels and sent_folder:
+        return sent_folder
+    return DEFAULT_TARGET_FOLDER
+
+
+def _normalize_email(value):
+    return str(value or "").strip().lower()

--- a/blocklist-admin/mailops/management/commands/run_gmail_import.py
+++ b/blocklist-admin/mailops/management/commands/run_gmail_import.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from mailops.gmail_import import GmailImportError, GmailImportService
+
+
+class Command(BaseCommand):
+    help = "Run a bounded historical Gmail import batch into a mailserver mailbox."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--account", required=True, help="Source Gmail account email.")
+        parser.add_argument("--target", required=True, help="Target mailserver mailbox email.")
+        parser.add_argument("--limit", type=int, default=100, help="Maximum Gmail messages to scan in this batch.")
+        parser.add_argument("--since", default="", help="Optional Gmail after: search value, for example 2026/04/01.")
+        parser.add_argument("--dry-run", action="store_true", help="List a bounded batch without appending, writing state, or deleting Gmail.")
+        parser.add_argument("--no-delete", action="store_true", help="Do not delete Gmail source messages for this run.")
+
+    def handle(self, *args, **options):
+        try:
+            result = GmailImportService().run_historical_import(
+                gmail_email=options["account"],
+                target_mailbox_email=options["target"],
+                limit=options["limit"],
+                since=options["since"],
+                dry_run=options["dry_run"],
+                no_delete=options["no_delete"],
+            )
+        except GmailImportError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Gmail import complete: "
+                f"scanned={result.scanned} appended={result.appended} committed={result.committed} "
+                f"cleaned={result.cleaned} skipped={result.skipped} failed={result.failed}"
+            )
+        )

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -25,6 +25,7 @@ from mail_integration.exceptions import (
     MailInvalidOperationError,
     MailSendError,
 )
+from mail_integration.gmail_client import GmailMessageRef, GmailRawMessage
 from mail_integration.mailbox_service import MailboxService
 from mail_integration.schemas import (
     MailAttachmentContent,
@@ -53,6 +54,7 @@ from .credential_crypto import (
     encrypt_credential_value,
     encrypt_mailbox_password,
 )
+from .gmail_import import GmailImportService
 from .mail_indexing import MailIndexService
 from .mail_indexing.runner import run_sync_cycle, select_accounts_for_sync
 from .mail_indexing.sync import FolderSyncResult, reconcile_recent_missing_messages
@@ -71,6 +73,56 @@ from .services import MailboxCleanupError, MailboxProvisioningError, create_mail
 
 
 TEST_ENCRYPTION_KEY = "DhbKZLv4bil01DI7X2u09Q69vebV7py6A9m9q0gOCfg="
+
+
+class FakeGmailClient:
+    def __init__(self, refs=(), raw_messages=None, events=None, delete_error=None):
+        self.refs = tuple(refs)
+        self.raw_messages = raw_messages or {}
+        self.events = events if events is not None else []
+        self.delete_error = delete_error
+        self.deleted = []
+        self.list_calls = []
+
+    def list_message_refs(self, query="", max_results=100, page_token=""):
+        self.list_calls.append({"query": query, "max_results": max_results, "page_token": page_token})
+        return self.refs[:max_results], ""
+
+    def fetch_raw_message(self, gmail_message_id):
+        self.events.append(f"fetch:{gmail_message_id}")
+        return self.raw_messages[gmail_message_id]
+
+    def delete_message(self, gmail_message_id):
+        self.events.append(f"delete:{gmail_message_id}")
+        if self.delete_error:
+            raise self.delete_error
+        self.deleted.append(gmail_message_id)
+
+
+class FakeImapClient:
+    def __init__(self, events=None, append_error=None, sent_folder="Sent"):
+        self.events = events if events is not None else []
+        self.append_error = append_error
+        self.sent_folder = sent_folder
+        self.appended = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return None
+
+    def login(self, credentials):
+        self.events.append(f"login:{credentials.email}")
+
+    def _resolve_sent_folder(self):
+        return self.sent_folder
+
+    def append_message(self, folder, message_bytes, flags=(r"\Seen",)):
+        self.events.append(f"append:{folder}")
+        if self.append_error:
+            raise self.append_error
+        self.appended.append((folder, message_bytes, flags))
 
 
 class MailboxProvisioningServiceTests(TestCase):
@@ -524,6 +576,205 @@ class MailApiTests(TestCase):
         self.assertEqual(account.get_refresh_token(), "refresh-secret")
         self.assertIn("Created Gmail import account", stdout.getvalue())
         exchange_code.assert_called_once()
+
+    def test_gmail_historical_import_dry_run_does_not_mutate_import_state(self):
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        gmail_client = FakeGmailClient(refs=(GmailMessageRef(gmail_message_id="gmail-1"),))
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: FakeImapClient(),
+        ).run_historical_import("source@gmail.com", self.account_email, limit=10, dry_run=True)
+
+        self.assertEqual(result.scanned, 1)
+        self.assertEqual(result.committed, 0)
+        self.assertEqual(GmailImportRun.objects.count(), 0)
+        self.assertEqual(GmailImportMessage.objects.count(), 0)
+        self.assertEqual(gmail_client.deleted, [])
+        self.assertIn("-in:drafts -in:spam -in:trash", gmail_client.list_calls[0]["query"])
+
+    def test_gmail_historical_import_appends_then_commits_without_default_delete(self):
+        token = create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        MailAccountIndex.objects.create(
+            user=token.user,
+            account_email=self.account_email,
+            index_status=MailAccountIndex.STATUS_READY,
+            last_indexed_at=timezone.now(),
+        )
+        events = []
+        gmail_client = FakeGmailClient(
+            refs=(GmailMessageRef(gmail_message_id="gmail-1", gmail_thread_id="thread-1"),),
+            raw_messages={
+                "gmail-1": GmailRawMessage(
+                    gmail_message_id="gmail-1",
+                    gmail_thread_id="thread-1",
+                    history_id="7",
+                    label_ids=("INBOX",),
+                    raw_bytes=b"Message-ID: <one@example.com>\r\n\r\nBody",
+                    rfc_message_id="<one@example.com>",
+                )
+            },
+            events=events,
+        )
+        imap_client = FakeImapClient(events=events)
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: imap_client,
+        ).run_historical_import("source@gmail.com", self.account_email, limit=10)
+
+        self.assertEqual(result.appended, 1)
+        self.assertEqual(result.committed, 1)
+        self.assertEqual(result.cleaned, 0)
+        self.assertEqual(events, ["login:user@example.com", "fetch:gmail-1", "append:INBOX"])
+        message = GmailImportMessage.objects.get()
+        self.assertEqual(message.state, GmailImportMessage.STATE_COMMITTED)
+        self.assertEqual(message.append_status, GmailImportMessage.STATUS_SUCCESS)
+        self.assertEqual(message.cleanup_status, GmailImportMessage.STATUS_PENDING)
+        self.assertEqual(message.target_folder, "INBOX")
+        self.assertEqual(message.rfc_message_id, "<one@example.com>")
+        self.assertEqual(gmail_client.deleted, [])
+        self.assertIsNone(MailAccountIndex.objects.get(account_email=self.account_email).last_indexed_at)
+        run = GmailImportRun.objects.get()
+        self.assertEqual(run.status, GmailImportRun.STATUS_SUCCESS)
+        self.assertEqual(run.committed_count, 1)
+
+    def test_gmail_historical_import_deletes_only_after_commit_when_enabled(self):
+        create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        events = []
+        gmail_client = FakeGmailClient(
+            refs=(GmailMessageRef(gmail_message_id="gmail-1"),),
+            raw_messages={
+                "gmail-1": GmailRawMessage(
+                    gmail_message_id="gmail-1",
+                    gmail_thread_id="thread-1",
+                    history_id="7",
+                    label_ids=("SENT",),
+                    raw_bytes=b"Message-ID: <sent@example.com>\r\n\r\nBody",
+                    rfc_message_id="<sent@example.com>",
+                )
+            },
+            events=events,
+        )
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: FakeImapClient(events=events, sent_folder="Sent"),
+        ).run_historical_import("source@gmail.com", self.account_email, limit=10)
+
+        self.assertEqual(result.cleaned, 1)
+        self.assertEqual(events, ["login:user@example.com", "fetch:gmail-1", "append:Sent", "delete:gmail-1"])
+        message = GmailImportMessage.objects.get()
+        self.assertEqual(message.state, GmailImportMessage.STATE_CLEANED)
+        self.assertEqual(message.cleanup_status, GmailImportMessage.STATUS_SUCCESS)
+        self.assertEqual(message.target_folder, "Sent")
+
+    def test_gmail_historical_import_does_not_delete_when_append_fails(self):
+        create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        events = []
+        gmail_client = FakeGmailClient(
+            refs=(GmailMessageRef(gmail_message_id="gmail-1"),),
+            raw_messages={
+                "gmail-1": GmailRawMessage(
+                    gmail_message_id="gmail-1",
+                    gmail_thread_id="thread-1",
+                    history_id="7",
+                    label_ids=("INBOX",),
+                    raw_bytes=b"Message-ID: <one@example.com>\r\n\r\nBody",
+                    rfc_message_id="<one@example.com>",
+                )
+            },
+            events=events,
+        )
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: FakeImapClient(events=events, append_error=MailConnectionError("append failed")),
+        ).run_historical_import("source@gmail.com", self.account_email, limit=10)
+
+        self.assertEqual(result.failed, 1)
+        self.assertEqual(result.cleaned, 0)
+        self.assertEqual(events, ["login:user@example.com", "fetch:gmail-1", "append:INBOX"])
+        self.assertEqual(gmail_client.deleted, [])
+        message = GmailImportMessage.objects.get()
+        self.assertEqual(message.state, GmailImportMessage.STATE_FAILED)
+        self.assertEqual(message.append_status, GmailImportMessage.STATUS_FAILED)
+        self.assertIsNone(message.committed_at)
+
+    def test_gmail_historical_import_recovers_appended_record_without_duplicate_append(self):
+        create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        GmailImportMessage.objects.create(
+            import_account=account,
+            gmail_message_id="gmail-1",
+            state=GmailImportMessage.STATE_APPENDED,
+            append_status=GmailImportMessage.STATUS_SUCCESS,
+            target_folder="INBOX",
+            appended_at=timezone.now(),
+        )
+        events = []
+        gmail_client = FakeGmailClient(refs=(GmailMessageRef(gmail_message_id="gmail-1"),), events=events)
+        imap_client = FakeImapClient(events=events)
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: imap_client,
+        ).run_historical_import("source@gmail.com", self.account_email, limit=10)
+
+        self.assertEqual(result.appended, 0)
+        self.assertEqual(result.committed, 1)
+        self.assertEqual(result.cleaned, 1)
+        self.assertEqual(events, ["login:user@example.com", "delete:gmail-1"])
+        message = GmailImportMessage.objects.get()
+        self.assertEqual(message.state, GmailImportMessage.STATE_CLEANED)
+
+    @patch("mailops.management.commands.run_gmail_import.GmailImportService")
+    def test_run_gmail_import_command_prints_summary(self, service_class):
+        service_class.return_value.run_historical_import.return_value = Mock(
+            scanned=2,
+            appended=1,
+            committed=1,
+            cleaned=0,
+            skipped=1,
+            failed=0,
+        )
+        stdout = io.StringIO()
+
+        call_command(
+            "run_gmail_import",
+            "--account",
+            "source@gmail.com",
+            "--target",
+            self.account_email,
+            "--limit",
+            "2",
+            "--dry-run",
+            "--no-delete",
+            stdout=stdout,
+        )
+
+        self.assertIn("scanned=2 appended=1 committed=1 cleaned=0 skipped=1 failed=0", stdout.getvalue())
+        service_class.return_value.run_historical_import.assert_called_once_with(
+            gmail_email="source@gmail.com",
+            target_mailbox_email=self.account_email,
+            limit=2,
+            since="",
+            dry_run=True,
+            no_delete=True,
+        )
 
     def test_legacy_plaintext_migration_encrypts_existing_rows(self):
         migration = importlib.import_module("mailops.migrations.0004_encrypt_mailbox_token_credentials")


### PR DESCRIPTION
## Summary
- add a bounded historical Gmail import service and `run_gmail_import` command
- import Gmail All Mail batches into the target mailserver mailbox with Gmail ID dedupe records
- preserve crash-aware state transitions: fetched -> appended -> committed -> cleaned
- keep Gmail cleanup disabled by default, with deletion only after committed state and only when enabled
- mark target mail indexes stale after committed imports so existing index refresh can pick them up

## Notes
This is PR 3 from issue #20. It intentionally does not add periodic `historyId` sync or Docker loop wiring yet; that belongs to PR 4.

The command supports:

```bash
python manage.py run_gmail_import --account source@gmail.com --target user@example.com --limit 100 --dry-run --no-delete
```

## Validation
- `docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mail_integration mailops`
- `docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py check`
- `docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py makemigrations --check --dry-run`

Part of #20.
