### PR TITLE
[codex] Add user scope to Gmail import accounts

### DIFF
--- a/blocklist-admin/mailops/admin.py
+++ b/blocklist-admin/mailops/admin.py
@@ -224,6 +224,7 @@ class GmailImportRunInline(admin.TabularInline):
 @admin.register(GmailImportAccount)
 class GmailImportAccountAdmin(admin.ModelAdmin):
     list_display = (
+        "user",
         "gmail_email",
         "target_mailbox_email",
         "delete_after_import",
@@ -233,7 +234,7 @@ class GmailImportAccountAdmin(admin.ModelAdmin):
         "updated_at",
     )
     list_filter = ("delete_after_import", "consecutive_failures")
-    search_fields = ("gmail_email", "target_mailbox_email", "last_history_id", "last_error")
+    search_fields = ("user__username", "user__email", "gmail_email", "target_mailbox_email", "last_history_id", "last_error")
     readonly_fields = ("refresh_token_status", "created_at", "updated_at")
     exclude = ("refresh_token",)
     inlines = (GmailImportRunInline, GmailImportMessageInline)

--- a/blocklist-admin/mailops/migrations/0008_gmail_import_user_scope.py
+++ b/blocklist-admin/mailops/migrations/0008_gmail_import_user_scope.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("mailops", "0007_gmail_import_foundation"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="gmailimportaccount",
+            name="user",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="gmail_import_accounts",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="gmailimportaccount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("user__isnull", False)),
+                fields=("user",),
+                name="uniq_gmail_import_acct_user",
+            ),
+        ),
+    ]

--- a/blocklist-admin/mailops/models.py
+++ b/blocklist-admin/mailops/models.py
@@ -195,6 +195,13 @@ class MailboxTokenCredential(models.Model):
 
 
 class GmailImportAccount(models.Model):
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="gmail_import_accounts",
+    )
     gmail_email = models.EmailField(unique=True, db_index=True)
     target_mailbox_email = models.EmailField(db_index=True)
     refresh_token = models.TextField()
@@ -209,6 +216,13 @@ class GmailImportAccount(models.Model):
 
     class Meta:
         ordering = ["gmail_email"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user"],
+                condition=models.Q(user__isnull=False),
+                name="uniq_gmail_import_acct_user",
+            ),
+        ]
         verbose_name = "Gmail import account"
         verbose_name_plural = "Gmail import accounts"
 
@@ -216,6 +230,17 @@ class GmailImportAccount(models.Model):
         self.gmail_email = self.gmail_email.strip().lower()
         self.target_mailbox_email = self.target_mailbox_email.strip().lower()
         self.last_history_id = (self.last_history_id or "").strip()
+        if self.user_id:
+            user_email = (self.user.email or "").strip().lower()
+            errors = {}
+            if not user_email:
+                errors["user"] = "Owning Django user must have an email before Gmail connection."
+            if user_email and self.gmail_email != user_email:
+                errors["gmail_email"] = "Gmail email must match the owning Django user email."
+            if user_email and self.target_mailbox_email != user_email:
+                errors["target_mailbox_email"] = "Target mailbox email must match the owning Django user email."
+            if errors:
+                raise ValidationError(errors)
 
     def set_refresh_token(self, plaintext):
         self.refresh_token = encrypt_credential_value(plaintext)

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -479,6 +479,48 @@ class MailApiTests(TestCase):
         self.assertEqual(stored.get_refresh_token(), "refresh-secret")
         self.assertFalse(stored.delete_after_import)
 
+    def test_user_scoped_gmail_import_account_matches_owner_email(self):
+        user = get_user_model().objects.create_user(username="source", email=" Source@Example.COM ", password="secret")
+        account = GmailImportAccount(user=user, gmail_email=" SOURCE@example.com ", target_mailbox_email=" source@example.com ")
+        account.set_refresh_token("refresh-secret")
+        account.save()
+
+        stored = GmailImportAccount.objects.get()
+        self.assertEqual(stored.user, user)
+        self.assertEqual(stored.gmail_email, "source@example.com")
+        self.assertEqual(stored.target_mailbox_email, "source@example.com")
+        self.assertEqual(stored.get_refresh_token(), "refresh-secret")
+
+    def test_user_scoped_gmail_import_account_rejects_mismatched_gmail_email(self):
+        user = get_user_model().objects.create_user(username="source", email="source@example.com", password="secret")
+        account = GmailImportAccount(user=user, gmail_email="other@example.com", target_mailbox_email="source@example.com")
+        account.set_refresh_token("refresh-secret")
+
+        with self.assertRaises(ValidationError) as ctx:
+            account.save()
+
+        self.assertIn("gmail_email", ctx.exception.message_dict)
+
+    def test_user_scoped_gmail_import_account_rejects_mismatched_target_mailbox(self):
+        user = get_user_model().objects.create_user(username="source", email="source@example.com", password="secret")
+        account = GmailImportAccount(user=user, gmail_email="source@example.com", target_mailbox_email="target@example.com")
+        account.set_refresh_token("refresh-secret")
+
+        with self.assertRaises(ValidationError) as ctx:
+            account.save()
+
+        self.assertIn("target_mailbox_email", ctx.exception.message_dict)
+
+    def test_legacy_gmail_import_account_can_remain_without_owner(self):
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email="target@example.com")
+        account.set_refresh_token("refresh-secret")
+        account.save()
+
+        stored = GmailImportAccount.objects.get()
+        self.assertIsNone(stored.user)
+        self.assertEqual(stored.gmail_email, "source@gmail.com")
+        self.assertEqual(stored.target_mailbox_email, "target@example.com")
+
     def test_gmail_import_message_uses_gmail_id_as_unique_source_key(self):
         account = GmailImportAccount.objects.create(
             gmail_email="source@gmail.com",
@@ -532,6 +574,8 @@ class MailApiTests(TestCase):
 
         self.assertIn("refresh_token", account_admin.exclude)
         self.assertIn("refresh_token_status", account_admin.readonly_fields)
+        self.assertIn("user", account_admin.list_display)
+        self.assertIn("user__email", account_admin.search_fields)
 
     @override_settings(
         GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",


### PR DESCRIPTION
## Summary

- add Django user ownership to Gmail import accounts
- enforce the v1 identity rule for user-scoped accounts: owner email, Gmail email, and target mailbox email must match
- keep legacy ownerless Gmail import accounts available as an admin/global compatibility path
- surface owner lookup in Django admin and cover the model rules with tests

## Validation

- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mailops
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py check
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py makemigrations --check --dry-run
- git diff --check
