### PR TITLE
[codex] Add user-scoped Gmail import authorization

### DIFF
--- a/blocklist-admin/mailops/gmail_import.py
+++ b/blocklist-admin/mailops/gmail_import.py
@@ -58,6 +58,30 @@ class GmailImportService:
             raise GmailImportError("--limit must be greater than zero")
 
         import_account = self._get_import_account(gmail_email, target_mailbox_email)
+        return self._run_historical_import_for_account(
+            import_account=import_account,
+            target_mailbox_email=target_mailbox_email,
+            limit=limit,
+            since=since,
+            dry_run=dry_run,
+            no_delete=no_delete,
+        )
+
+    def run_historical_import_for_user(self, user, limit=100, since="", dry_run=False, no_delete=False):
+        limit = int(limit)
+        if limit < 1:
+            raise GmailImportError("--limit must be greater than zero")
+        import_account = self._get_user_import_account(user)
+        return self._run_historical_import_for_account(
+            import_account=import_account,
+            target_mailbox_email=import_account.target_mailbox_email,
+            limit=limit,
+            since=since,
+            dry_run=dry_run,
+            no_delete=no_delete,
+        )
+
+    def _run_historical_import_for_account(self, import_account, target_mailbox_email, limit, since, dry_run, no_delete):
         run = None if dry_run else GmailImportRun.objects.create(import_account=import_account, mode=GmailImportRun.MODE_HISTORICAL)
 
         try:
@@ -132,6 +156,26 @@ class GmailImportService:
             raise GmailImportError("--limit must be greater than zero")
 
         import_account = self._get_import_account(gmail_email, target_mailbox_email)
+        return self._run_incremental_import_for_account(
+            import_account=import_account,
+            target_mailbox_email=target_mailbox_email,
+            limit=limit,
+            no_delete=no_delete,
+        )
+
+    def run_incremental_import_for_user(self, user, limit=100, no_delete=False):
+        limit = int(limit)
+        if limit < 1:
+            raise GmailImportError("--limit must be greater than zero")
+        import_account = self._get_user_import_account(user)
+        return self._run_incremental_import_for_account(
+            import_account=import_account,
+            target_mailbox_email=import_account.target_mailbox_email,
+            limit=limit,
+            no_delete=no_delete,
+        )
+
+    def _run_incremental_import_for_account(self, import_account, target_mailbox_email, limit, no_delete):
         run = GmailImportRun.objects.create(import_account=import_account, mode=GmailImportRun.MODE_INCREMENTAL)
         try:
             result = self._run_incremental_batch(
@@ -203,8 +247,8 @@ class GmailImportService:
         synced = failed = skipped = 0
         for account in accounts:
             try:
-                self.run_incremental_import(
-                    gmail_email=account.gmail_email,
+                self._run_incremental_import_for_account(
+                    import_account=account,
                     target_mailbox_email=account.target_mailbox_email,
                     limit=limit,
                     no_delete=no_delete,
@@ -260,7 +304,7 @@ class GmailImportService:
     def _import_refs(self, import_account, target_mailbox_email, run, refs, no_delete, gmail_client=None):
         gmail_client = gmail_client or self.gmail_client_factory(import_account.get_refresh_token())
         scanned = len(refs)
-        target_credentials = self._target_credentials(target_mailbox_email)
+        target_credentials = self._target_credentials(target_mailbox_email, owner=import_account.user)
         appended = committed = cleaned = skipped = failed = 0
         any_committed = False
         max_history_id = ""
@@ -339,11 +383,27 @@ class GmailImportService:
             raise GmailImportError(f"Gmail import account {gmail_email} is mapped to {account.target_mailbox_email}, not {target_mailbox_email}.")
         return account
 
-    def _target_credentials(self, target_mailbox_email):
+    def _get_user_import_account(self, user):
+        user_email = _normalize_email(getattr(user, "email", ""))
+        if not getattr(user, "is_authenticated", False):
+            raise GmailImportError("Authenticated Django user is required for user-scoped Gmail import.")
+        if not user_email:
+            raise GmailImportError("Django user must have an email before Gmail import.")
+        try:
+            account = GmailImportAccount.objects.get(user=user)
+        except GmailImportAccount.DoesNotExist as exc:
+            raise GmailImportError(f"No Gmail import account connected for {user_email}.") from exc
+        if account.gmail_email != user_email or account.target_mailbox_email != user_email:
+            raise GmailImportError(f"Gmail import account for {user_email} is not mapped to the owning user mailbox.")
+        return account
+
+    def _target_credentials(self, target_mailbox_email, owner=None):
         try:
             credential = MailboxTokenCredential.objects.select_related("token__user").get(mailbox_email=target_mailbox_email)
         except MailboxTokenCredential.DoesNotExist as exc:
             raise GmailImportError(f"No mailbox token credential found for target mailbox {target_mailbox_email}") from exc
+        if owner is not None and credential.token.user_id != owner.pk:
+            raise GmailImportError(f"Target mailbox {target_mailbox_email} is not owned by the Gmail import account user.")
         return MailboxCredentials(email=credential.mailbox_email, password=credential.get_mailbox_password())
 
     def _get_or_create_message_record(self, import_account, ref):

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -54,7 +54,7 @@ from .credential_crypto import (
     encrypt_credential_value,
     encrypt_mailbox_password,
 )
-from .gmail_import import GmailImportService
+from .gmail_import import GmailImportError, GmailImportService
 from .mail_indexing import MailIndexService
 from .mail_indexing.runner import run_sync_cycle, select_accounts_for_sync
 from .mail_indexing.sync import FolderSyncResult, reconcile_recent_missing_messages
@@ -840,6 +840,66 @@ class MailApiTests(TestCase):
         self.assertEqual(run.status, GmailImportRun.STATUS_SUCCESS)
         self.assertEqual(run.committed_count, 1)
 
+    def test_user_scoped_gmail_historical_import_resolves_owner_mailbox(self):
+        token = create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(user=token.user, gmail_email=self.account_email, target_mailbox_email=self.account_email)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        events = []
+        gmail_client = FakeGmailClient(
+            refs=(GmailMessageRef(gmail_message_id="gmail-1"),),
+            raw_messages={
+                "gmail-1": GmailRawMessage(
+                    gmail_message_id="gmail-1",
+                    gmail_thread_id="thread-1",
+                    history_id="7",
+                    label_ids=("INBOX",),
+                    raw_bytes=b"Message-ID: <one@example.com>\r\n\r\nBody",
+                    rfc_message_id="<one@example.com>",
+                )
+            },
+            events=events,
+        )
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: FakeImapClient(events=events),
+        ).run_historical_import_for_user(token.user, limit=10)
+
+        self.assertEqual(result.committed, 1)
+        self.assertEqual(events, ["login:user@example.com", "fetch:gmail-1", "append:INBOX"])
+        self.assertEqual(GmailImportRun.objects.get().import_account, account)
+
+    def test_user_scoped_gmail_import_rejects_other_user_without_connected_account(self):
+        owner_token = create_mailbox_token(self.account_email, self.password)
+        other_user = get_user_model().objects.create_user(username="other@example.com", email="other@example.com", password="secret")
+        account = GmailImportAccount(user=owner_token.user, gmail_email=self.account_email, target_mailbox_email=self.account_email)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+
+        with self.assertRaisesRegex(GmailImportError, "No Gmail import account connected for other@example.com"):
+            GmailImportService(
+                gmail_client_factory=lambda refresh_token: FakeGmailClient(),
+                imap_client_factory=lambda: FakeImapClient(),
+            ).run_historical_import_for_user(other_user, limit=10)
+
+    def test_user_scoped_gmail_import_rejects_mailbox_credentials_owned_by_another_user(self):
+        owner = get_user_model().objects.create_user(username="user@example.com", email=self.account_email, password="secret")
+        other_user = get_user_model().objects.create_user(username="other@example.com", email="other@example.com", password="secret")
+        other_token = Token.objects.create(user=other_user)
+        credential = MailboxTokenCredential(token=other_token, mailbox_email=self.account_email)
+        credential.set_mailbox_password(self.password)
+        credential.save()
+        account = GmailImportAccount(user=owner, gmail_email=self.account_email, target_mailbox_email=self.account_email)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+
+        with self.assertRaisesRegex(GmailImportError, "not owned by the Gmail import account user"):
+            GmailImportService(
+                gmail_client_factory=lambda refresh_token: FakeGmailClient(refs=(GmailMessageRef(gmail_message_id="gmail-1"),)),
+                imap_client_factory=lambda: FakeImapClient(),
+            ).run_historical_import_for_user(owner, limit=10)
+
     def test_gmail_historical_import_deletes_only_after_commit_when_enabled(self):
         create_mailbox_token(self.account_email, self.password)
         account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
@@ -1014,6 +1074,23 @@ class MailApiTests(TestCase):
         self.assertEqual(run.status, GmailImportRun.STATUS_SUCCESS)
         self.assertEqual(gmail_client.history_calls[0]["start_history_id"], "10")
         self.assertEqual(gmail_client.list_calls, [])
+
+    def test_user_scoped_gmail_incremental_import_uses_owner_account(self):
+        token = create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(user=token.user, gmail_email=self.account_email, target_mailbox_email=self.account_email, last_history_id="10")
+        account.set_refresh_token("refresh-secret")
+        account.historical_import_completed_at = timezone.now()
+        account.save()
+        gmail_client = FakeGmailClient(history_pages=(GmailHistoryPage(history_id="10"),))
+
+        result = GmailImportService(
+            gmail_client_factory=lambda refresh_token: gmail_client,
+            imap_client_factory=lambda: FakeImapClient(),
+        ).run_incremental_import_for_user(token.user, limit=10)
+
+        self.assertEqual(result.scanned, 0)
+        self.assertEqual(GmailImportRun.objects.get().import_account, account)
+        self.assertEqual(gmail_client.history_calls[0]["start_history_id"], "10")
 
     def test_gmail_incremental_import_does_not_advance_cursor_on_partial_failure(self):
         create_mailbox_token(self.account_email, self.password)


### PR DESCRIPTION
## Summary

- add user-scoped historical and incremental Gmail import service entrypoints
- resolve Gmail import accounts through the owning Django user for future user-facing sync flows
- enforce that user-scoped imports use mailbox credentials owned by the same Django user
- keep legacy admin/global command-compatible import paths working

## Validation

- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mailops
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py check
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py makemigrations --check --dry-run
- git diff --check

Note: an earlier parallel targeted test run collided on the shared Django test database name; rerunning sequentially passed.
