### PR TITLE
[codex] Document user-scoped Gmail import rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ docker compose logs -f gmail-import-sync
 docker compose exec mailadmin python manage.py run_gmail_import --help
 ```
 
-Setup, OAuth bootstrap, historical import, incremental sync, and smoke-test
-commands are documented in [docs/gmail-import.md](/opt/stacks/mailserver/docs/gmail-import.md).
+User-scoped Gmail onboarding, OAuth connection API, historical import,
+incremental sync, admin compatibility commands, and smoke-test checks are
+documented in [docs/gmail-import.md](/opt/stacks/mailserver/docs/gmail-import.md).
 
 - backup:
 

--- a/docs/gmail-import.md
+++ b/docs/gmail-import.md
@@ -1,9 +1,16 @@
 # Gmail Import
 
-This document describes the operational path for importing one Gmail account into
-one existing mailserver mailbox through `mailadmin`.
+This document describes the user-scoped Gmail import flow in `mailadmin`.
 
-The importer is intentionally conservative:
+The v1 model is intentionally strict:
+
+- one Django user maps to one Gmail account and one local mailserver mailbox
+- the connected Gmail address must exactly match the Django user email
+- onboarding is admin-managed through Django admin
+- Gmail access is OAuth-only; admins must not enter or store Gmail passwords
+- mailbox read/send APIs continue to use the local mailserver mailbox
+
+The importer remains conservative:
 
 - Gmail access uses OAuth and the Gmail API.
 - The target side writes raw RFC822 messages through the mailserver IMAP service.
@@ -15,8 +22,9 @@ The importer is intentionally conservative:
 
 ## Scope
 
-v1 supports one Gmail source account mapped to one target mailserver mailbox per
-`GmailImportAccount` row.
+v1 supports one Gmail source account per Django user. The connected Gmail source,
+the Django user email, and the target mailserver mailbox must be the same
+normalized email address.
 
 Imported source:
 
@@ -31,40 +39,69 @@ Target mapping:
 
 Out of scope for v1:
 
+- user self-signup
+- generic IMAP, POP, or SMTP external accounts
+- connecting a Gmail account with a different email than the Django user
+- connecting multiple Gmail accounts to one Django user
 - mirroring Gmail labels into IMAP folders
 - Gmail archive cleanup mode
 - importing Gmail Drafts, Spam, or Trash
-- mobile API changes
 
-## Prerequisites
+## Admin-Managed Onboarding
 
-The target mailbox must already exist on this mailserver and must have stored
-mailbox credentials in `mailadmin`.
+Create the Django user and local mailbox before Gmail connection. The password
+here is the application/mailserver password, not a Gmail password.
 
-Create or confirm the mailbox:
-
-```bash
-./scripts/mail.sh email add user@finestar.hr 'StrongPasswordHere'
-./scripts/mail.sh debug login user@finestar.hr 'StrongPasswordHere'
-```
-
-Store target mailbox credentials by logging in once through the existing mailbox
-API, or confirm they already exist:
+With mailbox auto-provisioning enabled:
 
 ```bash
-docker compose exec -T mailadmin python manage.py shell
+MAILBOX_AUTO_CREATE_FROM_USER_ADMIN=true
+MAILBOX_AUTO_CREATE_SKIP_STAFF=true
 ```
 
-```python
-from mailops.models import MailboxTokenCredential
+Then:
 
-MailboxTokenCredential.objects.filter(mailbox_email="user@finestar.hr").exists()
+1. Open `https://${MAILADMIN_HOST}/admin/`.
+2. Add a non-staff Django user.
+3. Set `username`, `email`, `password`, and `password confirmation`.
+4. Save the user.
+5. Confirm the mailbox exists and login works:
+
+```bash
+./scripts/mail.sh debug login user@example.com 'PasswordFromAdmin'
+```
+
+If mailbox auto-provisioning is not enabled, create the mailbox manually:
+
+```bash
+./scripts/mail.sh email add user@example.com 'StrongPasswordHere'
+./scripts/mail.sh debug login user@example.com 'StrongPasswordHere'
+```
+
+The user must log in through the mailbox API at least once so `mailadmin` stores
+the local mailbox credential used by Gmail import:
+
+```bash
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"StrongPasswordHere"}'
+```
+
+Confirm stored credentials:
+
+```bash
+docker compose exec -T mailadmin python manage.py shell -c \
+  'from mailops.models import MailboxTokenCredential; print(MailboxTokenCredential.objects.filter(mailbox_email="user@example.com").exists())'
 ```
 
 ## Google OAuth Setup
 
-Create an OAuth client in Google Cloud for the Gmail source account. The importer
-uses the Gmail modify scope:
+Create a Google OAuth client for the mailadmin app. The redirect URI must be the
+URI used by the client/operator flow that receives Google's `code` and `state`
+and then posts them to the `connect/complete` API endpoint. The backend currently
+does not expose a browser callback page by itself.
+
+The importer uses the Gmail modify scope:
 
 ```text
 https://www.googleapis.com/auth/gmail.modify
@@ -75,93 +112,131 @@ Set these values in the local `.env`:
 ```bash
 GMAIL_IMPORT_GOOGLE_CLIENT_ID=google-client-id
 GMAIL_IMPORT_GOOGLE_CLIENT_SECRET=google-client-secret
-GMAIL_IMPORT_OAUTH_REDIRECT_URI=urn:ietf:wg:oauth:2.0:oob
+GMAIL_IMPORT_OAUTH_REDIRECT_URI=https://app.example.com/oauth/gmail/callback
 GMAIL_IMPORT_OAUTH_SCOPES=https://www.googleapis.com/auth/gmail.modify
 GMAIL_IMPORT_SYNC_INTERVAL_SECONDS=600
 GMAIL_IMPORT_SYNC_LIMIT=100
 GMAIL_IMPORT_SYNC_MAX_ACCOUNTS=20
 ```
 
-Rebuild and restart `mailadmin` after adding dependencies or changing env:
+Restart `mailadmin` after changing env:
 
 ```bash
 docker compose up -d --build mailadmin
 ```
 
-When enabling the periodic sync service later:
+When enabling the periodic sync service:
 
 ```bash
 docker compose up -d --build gmail-import-sync
 ```
 
-## Bootstrap OAuth
+## User-Facing Gmail Connection API
 
-Print the Google consent URL:
+All user-facing endpoints require the existing token authentication from
+`/api/auth/login`. The token user, mailbox credential email, Django user email,
+and Gmail OAuth identity must match.
 
-```bash
-docker compose exec -T mailadmin python manage.py bootstrap_gmail_import_oauth \
-  --gmail source@gmail.com \
-  --target user@finestar.hr
-```
-
-Open the printed URL, authorize access, then store the returned authorization
-code:
+Start Gmail OAuth:
 
 ```bash
-docker compose exec -T mailadmin python manage.py bootstrap_gmail_import_oauth \
-  --gmail source@gmail.com \
-  --target user@finestar.hr \
-  --code 'GOOGLE_AUTHORIZATION_CODE'
+TOKEN="mailadmin-token-from-login"
+
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/connect/start" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
 ```
 
-Confirm the import account exists without exposing the encrypted token:
+The response contains:
+
+```json
+{
+  "authorization_url": "https://accounts.google.com/...",
+  "state": "signed-state",
+  "account_email": "user@example.com"
+}
+```
+
+Open `authorization_url`, complete Google consent with the matching Gmail
+account, then submit the returned authorization code and state:
 
 ```bash
-docker compose exec -T mailadmin python manage.py shell
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/connect/complete" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"code":"GOOGLE_AUTHORIZATION_CODE","state":"SIGNED_STATE_FROM_START"}'
 ```
 
-```python
-from mailops.models import GmailImportAccount
+OAuth completion is rejected when Google reports any Gmail address other than
+the authenticated Django user email.
 
-account = GmailImportAccount.objects.get(gmail_email="source@gmail.com")
-print(account.gmail_email, account.target_mailbox_email, account.delete_after_import)
+Read connected account status:
+
+```bash
+curl -sS "https://${MAILADMIN_HOST}/api/external-accounts/gmail" \
+  -H "Authorization: Token ${TOKEN}"
 ```
 
-`delete_after_import` defaults to `False`.
+List external accounts:
+
+```bash
+curl -sS "https://${MAILADMIN_HOST}/api/external-accounts" \
+  -H "Authorization: Token ${TOKEN}"
+```
+
+The Gmail account contract includes:
+
+```json
+{
+  "connected": true,
+  "provider": "gmail",
+  "gmail_email": "user@example.com",
+  "target_mailbox_email": "user@example.com",
+  "delete_after_import": false,
+  "last_success_at": null,
+  "last_error": "",
+  "historical_import_completed": false,
+  "historical_import_completed_at": null,
+  "consecutive_failures": 0
+}
+```
+
+Disconnect Gmail:
+
+```bash
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/disconnect" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Disconnect deletes only the authenticated user's Gmail connection. It does not
+delete the Django user, local mailbox, imported mail, or another user's Gmail
+connection.
 
 ## Historical Import
 
-Start with a dry run. Dry run fetches a bounded Gmail message list only; it does
-not append to IMAP, write import records, or clean Gmail.
+Use the bounded sync trigger for user-facing imports. `mode=auto` runs
+historical import until `historical_import_completed_at` is set, then switches to
+incremental.
+
+Run a first bounded import without Gmail cleanup:
 
 ```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --limit 50 \
-  --dry-run \
-  --no-delete
-```
-
-Run the first bounded import without Gmail cleanup:
-
-```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --limit 100 \
-  --no-delete
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/sync" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"historical","limit":100,"no_delete":true}'
 ```
 
 Optional date-bounded import:
 
 ```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --limit 100 \
-  --since 2026/04/01 \
-  --no-delete
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/sync" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"historical","limit":100,"since":"2026/04/01","no_delete":true}'
 ```
 
 Inspect import state:
@@ -173,7 +248,7 @@ docker compose exec -T mailadmin python manage.py shell
 ```python
 from mailops.models import GmailImportAccount, GmailImportMessage, GmailImportRun
 
-account = GmailImportAccount.objects.get(gmail_email="source@gmail.com")
+account = GmailImportAccount.objects.get(user__email="user@example.com")
 print(account.last_success_at, account.last_history_id, account.last_error)
 print(GmailImportRun.objects.filter(import_account=account).latest("started_at").status)
 print(GmailImportMessage.objects.filter(import_account=account).values("state").order_by("state"))
@@ -188,37 +263,35 @@ docker compose exec -T mailadmin python manage.py shell
 ```python
 from mailops.models import GmailImportAccount
 
-account = GmailImportAccount.objects.get(gmail_email="source@gmail.com")
+account = GmailImportAccount.objects.get(user__email="user@example.com")
 account.delete_after_import = True
 account.save(update_fields=["delete_after_import", "updated_at"])
 ```
 
-Run another bounded import. Gmail source messages are deleted only after the
-message reaches committed import state:
+Run another bounded sync without `no_delete`. Gmail source messages are deleted
+only after the message reaches committed import state:
 
 ```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --limit 100
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/sync" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"auto","limit":100}'
 ```
 
-Use `--no-delete` any time you want to override cleanup for one run.
+Use `"no_delete": true` any time you want to override cleanup for one run.
 
 ## Incremental Sync
 
 After a successful historical import, the importer stores
 `historical_import_completed_at` and a Gmail `last_history_id` when available.
 
-Run one incremental batch for a single account:
+Run one bounded user-scoped incremental sync:
 
 ```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --incremental \
-  --limit 100 \
-  --no-delete
+curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/sync" \
+  -H "Authorization: Token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"incremental","limit":100,"no_delete":true}'
 ```
 
 Run one incremental cycle for all configured accounts that completed historical
@@ -248,6 +321,39 @@ avoid duplicate appends.
 The cursor advances only after a failure-free batch. Partial failures keep the
 previous cursor so the next run can retry safely.
 
+## Admin Compatibility Commands
+
+The old management-command flow remains available for admin/global compatibility
+and smoke testing. New user-facing work should use the user-scoped API flow.
+
+Print a Google consent URL:
+
+```bash
+docker compose exec -T mailadmin python manage.py bootstrap_gmail_import_oauth \
+  --gmail user@example.com \
+  --target user@example.com
+```
+
+Store the returned authorization code:
+
+```bash
+docker compose exec -T mailadmin python manage.py bootstrap_gmail_import_oauth \
+  --gmail user@example.com \
+  --target user@example.com \
+  --code 'GOOGLE_AUTHORIZATION_CODE'
+```
+
+Run a dry run from the compatibility path:
+
+```bash
+docker compose exec -T mailadmin python manage.py run_gmail_import \
+  --account user@example.com \
+  --target user@example.com \
+  --limit 50 \
+  --dry-run \
+  --no-delete
+```
+
 ## Index Refresh
 
 The importer appends raw messages into IMAP. The mail index is a downstream
@@ -258,7 +364,7 @@ Force a full bounded index refresh:
 
 ```bash
 docker compose exec -T mailadmin python manage.py sync_mail_index \
-  --account user@finestar.hr \
+  --account user@example.com \
   --limit 500 \
   --full
 ```
@@ -272,68 +378,47 @@ docker compose exec -T mailadmin python manage.py shell
 ```python
 from mailops.models import MailAccountIndex
 
-index = MailAccountIndex.objects.get(account_email="user@finestar.hr")
+index = MailAccountIndex.objects.get(account_email="user@example.com")
 print(index.index_status, index.last_indexed_at, index.last_sync_error)
 ```
 
-## Smoke Path
+## Two-User Isolation Smoke Path
 
-Use this minimal path for first production validation:
+Use this path to prove isolation before broader rollout:
 
-1. Confirm target mailbox login:
-
-```bash
-./scripts/mail.sh debug login user@finestar.hr 'StrongPasswordHere'
-```
-
-2. Confirm stored mailbox credentials:
-
-```bash
-docker compose exec -T mailadmin python manage.py shell -c \
-  'from mailops.models import MailboxTokenCredential; print(MailboxTokenCredential.objects.filter(mailbox_email="user@finestar.hr").exists())'
-```
-
-3. Bootstrap Gmail OAuth.
-
-4. Dry run:
+1. Create two Django users and local mailboxes:
+   - `user-a@example.com`
+   - `user-b@example.com`
+2. Log in each user through `/api/auth/login` and keep separate tokens.
+3. Connect Gmail for user A with `user-a@example.com`.
+4. Connect Gmail for user B with `user-b@example.com`.
+5. Confirm each token sees only its own account:
 
 ```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --limit 10 \
-  --dry-run \
-  --no-delete
+curl -sS "https://${MAILADMIN_HOST}/api/external-accounts" \
+  -H "Authorization: Token ${TOKEN_A}"
+
+curl -sS "https://${MAILADMIN_HOST}/api/external-accounts" \
+  -H "Authorization: Token ${TOKEN_B}"
 ```
 
-5. Import without Gmail cleanup:
+6. Run bounded sync for user A and confirm imports target only
+   `user-a@example.com`.
+7. Run bounded sync for user B and confirm imports target only
+   `user-b@example.com`.
+8. Disconnect user A and confirm user B's account still exists.
 
-```bash
-docker compose exec -T mailadmin python manage.py run_gmail_import \
-  --account source@gmail.com \
-  --target user@finestar.hr \
-  --limit 10 \
-  --no-delete
-```
-
-6. Refresh the mail index:
-
-```bash
-docker compose exec -T mailadmin python manage.py sync_mail_index \
-  --account user@finestar.hr \
-  --limit 100 \
-  --full
-```
-
-7. Inspect import records:
+Useful shell checks:
 
 ```bash
 docker compose exec -T mailadmin python manage.py shell -c \
-  'from mailops.models import GmailImportMessage; print(list(GmailImportMessage.objects.values("gmail_message_id", "state", "target_folder")[:10]))'
+  'from mailops.models import GmailImportAccount; print(list(GmailImportAccount.objects.values("user__email", "gmail_email", "target_mailbox_email")))'
 ```
 
-8. Enable `delete_after_import=True` only after the imported messages are visible
-   in the target mailbox and import records look correct.
+```bash
+docker compose exec -T mailadmin python manage.py shell -c \
+  'from mailops.models import GmailImportMessage; print(list(GmailImportMessage.objects.values("import_account__user__email", "gmail_message_id", "state", "target_folder")[:20]))'
+```
 
 ## Troubleshooting
 
@@ -341,11 +426,18 @@ OAuth config missing:
 
 - confirm `GMAIL_IMPORT_GOOGLE_CLIENT_ID`
 - confirm `GMAIL_IMPORT_GOOGLE_CLIENT_SECRET`
+- confirm `GMAIL_IMPORT_OAUTH_REDIRECT_URI`
 - rebuild/restart `mailadmin`
+
+OAuth completion rejected:
+
+- confirm the Google consent account exactly matches the Django user email
+- confirm the API token belongs to that same Django user
+- confirm mailbox credential email matches `request.user.email`
 
 Target mailbox credential missing:
 
-- login once through the mailbox API
+- log in once through `/api/auth/login`
 - confirm `MailboxTokenCredential` exists for the target mailbox
 
 History cursor expired:
@@ -357,7 +449,7 @@ History cursor expired:
 Partial import run:
 
 - inspect failed `GmailImportMessage.error`
-- rerun the same command; committed messages are skipped and failed messages are
+- rerun bounded sync; committed messages are skipped and failed messages are
   retried
 - do not enable `delete_after_import` until the failure mode is understood
 
@@ -365,7 +457,7 @@ Cleanup failed:
 
 - messages remain in committed state with `cleanup_status=failed`
 - rerun with cleanup enabled to retry Gmail deletion
-- use `--no-delete` to pause cleanup while investigating
+- use `"no_delete": true` to pause cleanup while investigating
 
 Logs:
 


### PR DESCRIPTION
## Summary

- update Gmail import docs for the user-scoped v1 rollout
- document admin-managed onboarding, OAuth-only Gmail consent, matching-email rejection, and user-facing account APIs
- document bounded historical/incremental sync, admin compatibility commands, and two-user isolation smoke checks
- update the README Gmail import reference to point at the user-scoped workflow

## Validation

- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py check
- git diff --check

Docs-only PR; full test suite was not rerun.
