### PR TITLE
[codex] Add Gmail admin browser OAuth callback

### DIFF
--- a/blocklist-admin/mailops/admin.py
+++ b/blocklist-admin/mailops/admin.py
@@ -9,8 +9,14 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import HttpResponseRedirect
+from django.urls import path, reverse
+from django.utils.html import format_html
+
+from mail_integration.exceptions import MailIntegrationError
+from mail_integration.gmail_client import build_authorization_url, oauth_config_from_settings
 
 from .forms import SenderBlocklistRuleForm
+from .api import signed_gmail_oauth_state
 from .models import (
     ApplyLog,
     DeviceRegistration,
@@ -84,6 +90,15 @@ admin.site.unregister(User)
 class MailboxUserAdmin(DjangoUserAdmin):
     add_form = MailboxUserCreationForm
     form = MailboxUserChangeForm
+    readonly_fields = DjangoUserAdmin.readonly_fields + ("gmail_connection_status", "gmail_connect_link")
+    fieldsets = DjangoUserAdmin.fieldsets + (
+        (
+            "Gmail import",
+            {
+                "fields": ("gmail_connection_status", "gmail_connect_link"),
+            },
+        ),
+    )
     add_fieldsets = (
         (
             None,
@@ -93,6 +108,59 @@ class MailboxUserAdmin(DjangoUserAdmin):
             },
         ),
     )
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<path:object_id>/connect-gmail/",
+                self.admin_site.admin_view(self.connect_gmail_view),
+                name="auth_user_connect_gmail",
+            ),
+        ]
+        return custom_urls + urls
+
+    def gmail_connection_status(self, obj):
+        if not obj or not obj.pk:
+            return "Save the user before connecting Gmail."
+        account = obj.gmail_import_accounts.first()
+        if account is None:
+            return "Not connected"
+        if account.refresh_token:
+            return f"Connected as {account.gmail_email}"
+        return "Account exists without OAuth token"
+
+    def gmail_connect_link(self, obj):
+        if not obj or not obj.pk:
+            return "Save the user before connecting Gmail."
+        if not normalize_mailbox_email(obj.email):
+            return "User email is required before Gmail connection."
+        url = reverse("admin:auth_user_connect_gmail", args=[obj.pk])
+        return format_html('<a class="button" href="{}">Connect Gmail</a>', url)
+
+    def connect_gmail_view(self, request, object_id):
+        user = self.get_object(request, object_id)
+        changelist_url = reverse("admin:auth_user_changelist")
+        if user is None:
+            self.message_user(request, "User not found.", level=messages.ERROR)
+            return HttpResponseRedirect(changelist_url)
+        change_url = reverse("admin:auth_user_change", args=[user.pk])
+        email = normalize_mailbox_email(user.email)
+        if not email:
+            self.message_user(request, "User email is required before Gmail connection.", level=messages.ERROR)
+            return HttpResponseRedirect(change_url)
+        try:
+            oauth_config = oauth_config_from_settings()
+            authorization_url = build_authorization_url(oauth_config, state=signed_gmail_oauth_state(user))
+        except MailIntegrationError as exc:
+            self.message_user(request, f"Gmail OAuth configuration failed: {exc}", level=messages.ERROR)
+            return HttpResponseRedirect(change_url)
+        self.message_user(
+            request,
+            "The browser consent step must be completed by the owner of the matching Gmail account.",
+            level=messages.INFO,
+        )
+        return HttpResponseRedirect(authorization_url)
 
     def should_provision_mailbox(self, obj):
         if not mailbox_auto_create_enabled():

--- a/blocklist-admin/mailops/api.py
+++ b/blocklist-admin/mailops/api.py
@@ -1,5 +1,6 @@
 import logging
 import secrets
+import time
 from email.utils import getaddresses
 
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
@@ -8,8 +9,10 @@ from django.contrib.auth import get_user_model
 from django.core import signing
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
+from django.urls import reverse
 from django.utils.http import content_disposition_header
 from django.utils import timezone
+from django.utils.html import escape
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.authtoken.models import Token
@@ -180,6 +183,7 @@ def signed_gmail_oauth_state(user):
             "user_id": user.pk,
             "email": (user.email or "").strip().lower(),
             "nonce": secrets.token_urlsafe(16),
+            "iat": int(time.time()),
         },
         salt=GMAIL_OAUTH_STATE_SALT,
     )
@@ -230,6 +234,38 @@ def require_user_mailbox_identity(request):
 
 def user_gmail_account(user):
     return GmailImportAccount.objects.filter(user=user).first()
+
+
+def upsert_user_gmail_account(user, refresh_token):
+    account_email = (user.email or "").strip().lower()
+    account = GmailImportAccount.objects.filter(user=user).first()
+    if account is None:
+        account = GmailImportAccount.objects.filter(user__isnull=True, gmail_email=account_email).first()
+    if account is None:
+        account = GmailImportAccount(user=user)
+    account.user = user
+    account.gmail_email = account_email
+    account.target_mailbox_email = account_email
+    account.last_error = ""
+    account.consecutive_failures = 0
+    account.set_refresh_token(refresh_token)
+    account.save()
+    return account
+
+
+def gmail_oauth_result_html(title, message, status_code=200, admin_url=""):
+    admin_link = ""
+    if admin_url:
+        admin_link = f'<p><a href="{escape(admin_url)}">Back to Django admin</a></p>'
+    return HttpResponse(
+        (
+            "<!doctype html><html><head><meta charset=\"utf-8\">"
+            f"<title>{escape(title)}</title></head><body>"
+            f"<h1>{escape(title)}</h1><p>{escape(message)}</p>{admin_link}"
+            "</body></html>"
+        ),
+        status=status_code,
+    )
 
 
 def folder_payload(folder):
@@ -694,22 +730,71 @@ class GmailConnectCompleteView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        account = GmailImportAccount.objects.filter(user=request.user).first()
-        if account is None:
-            account = GmailImportAccount.objects.filter(user__isnull=True, gmail_email=account_email).first()
-        if account is None:
-            account = GmailImportAccount(user=request.user)
-        account.user = request.user
-        account.gmail_email = account_email
-        account.target_mailbox_email = account_email
-        account.last_error = ""
-        account.consecutive_failures = 0
-        account.set_refresh_token(refresh_token)
         try:
-            account.save()
+            account = upsert_user_gmail_account(request.user, refresh_token)
         except ValidationError as exc:
             return Response({"error": "gmail_account_invalid", "detail": exc.message_dict}, status=status.HTTP_400_BAD_REQUEST)
         return Response(gmail_account_payload(account))
+
+
+class GmailOAuthCallbackView(APIView):
+    authentication_classes = []
+    permission_classes = []
+
+    @extend_schema(exclude=True)
+    def get(self, request):
+        admin_url = reverse("admin:mailops_gmailimportaccount_changelist")
+        oauth_error = (request.GET.get("error") or "").strip()
+        if oauth_error:
+            return gmail_oauth_result_html("Gmail connection failed", f"Google returned OAuth error: {oauth_error}", 400, admin_url)
+        code = (request.GET.get("code") or "").strip()
+        raw_state = (request.GET.get("state") or "").strip()
+        if not code or not raw_state:
+            return gmail_oauth_result_html("Gmail connection failed", "Missing OAuth code or state.", 400, admin_url)
+        try:
+            payload = signing.loads(raw_state, salt=GMAIL_OAUTH_STATE_SALT, max_age=600)
+        except signing.BadSignature:
+            return gmail_oauth_result_html("Gmail connection failed", "OAuth state is invalid or expired.", 400, admin_url)
+        user_id = payload.get("user_id")
+        expected_email = str(payload.get("email") or "").strip().lower()
+        User = get_user_model()
+        user = User.objects.filter(pk=user_id).first()
+        if user is None:
+            return gmail_oauth_result_html("Gmail connection failed", "The target Django user no longer exists.", 400, admin_url)
+        account_email = (user.email or "").strip().lower()
+        user_admin_url = reverse("admin:auth_user_change", args=[user.pk])
+        if not account_email or account_email != expected_email:
+            return gmail_oauth_result_html("Gmail connection failed", "The target Django user email changed before OAuth completion.", 400, user_admin_url)
+
+        try:
+            oauth_config = oauth_config_from_settings()
+            refresh_token = exchange_code_for_refresh_token(code, oauth_config)
+            gmail_email = fetch_gmail_profile_email(refresh_token, oauth_config)
+        except MailIntegrationError as exc:
+            return gmail_oauth_result_html("Gmail connection failed", str(exc), 502, user_admin_url)
+
+        if gmail_email != account_email:
+            return gmail_oauth_result_html(
+                "Gmail connection rejected",
+                f"Connected Gmail account {gmail_email} must match Django user email {account_email}.",
+                400,
+                user_admin_url,
+            )
+
+        try:
+            upsert_user_gmail_account(user, refresh_token)
+        except ValidationError as exc:
+            return gmail_oauth_result_html("Gmail connection failed", str(exc), 400, user_admin_url)
+
+        credential_exists = MailboxTokenCredential.objects.filter(mailbox_email=account_email).exists()
+        if credential_exists:
+            message = f"Gmail account {gmail_email} is connected for {account_email}."
+        else:
+            message = (
+                f"Gmail account {gmail_email} is connected for {account_email}, "
+                "but sync cannot run until the user logs in once through the mailbox API."
+            )
+        return gmail_oauth_result_html("Gmail connected", message, 200, user_admin_url)
 
 
 class ExternalAccountsView(APIView):

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -773,6 +773,84 @@ class MailApiTests(TestCase):
         exchange_code.assert_called_once()
         fetch_profile_email.assert_called_once()
 
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="https://mailadmin.example.com/oauth/gmail/callback",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+    )
+    @patch("mailops.api.fetch_gmail_profile_email", return_value="user@example.com")
+    @patch("mailops.api.exchange_code_for_refresh_token", return_value="refresh-secret")
+    def test_gmail_oauth_callback_connects_matching_user(self, exchange_code, fetch_profile_email):
+        token = create_mailbox_token(self.account_email, self.password)
+        oauth_state = signed_gmail_oauth_state(token.user)
+
+        response = self.client.get(reverse("mailops:gmail_oauth_callback"), {"code": "auth-code", "state": oauth_state})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Gmail connected", response.content)
+        account = GmailImportAccount.objects.get()
+        self.assertEqual(account.user, token.user)
+        self.assertEqual(account.gmail_email, self.account_email)
+        self.assertEqual(account.target_mailbox_email, self.account_email)
+        self.assertEqual(account.get_refresh_token(), "refresh-secret")
+        exchange_code.assert_called_once()
+        fetch_profile_email.assert_called_once()
+
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="https://mailadmin.example.com/oauth/gmail/callback",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+    )
+    @patch("mailops.api.fetch_gmail_profile_email", return_value="other@example.com")
+    @patch("mailops.api.exchange_code_for_refresh_token", return_value="refresh-secret")
+    def test_gmail_oauth_callback_rejects_mismatched_gmail_identity(self, exchange_code, fetch_profile_email):
+        user = get_user_model().objects.create_user(username=self.account_email, email=self.account_email, password="secret")
+        oauth_state = signed_gmail_oauth_state(user)
+
+        response = self.client.get(reverse("mailops:gmail_oauth_callback"), {"code": "auth-code", "state": oauth_state})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"Gmail connection rejected", response.content)
+        self.assertEqual(GmailImportAccount.objects.count(), 0)
+        exchange_code.assert_called_once()
+        fetch_profile_email.assert_called_once()
+
+    @patch("mailops.api.exchange_code_for_refresh_token")
+    def test_gmail_oauth_callback_rejects_invalid_state(self, exchange_code):
+        response = self.client.get(reverse("mailops:gmail_oauth_callback"), {"code": "auth-code", "state": "bad-state"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"OAuth state is invalid or expired", response.content)
+        exchange_code.assert_not_called()
+
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="https://mailadmin.example.com/oauth/gmail/callback",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+    )
+    @patch("mailops.admin.build_authorization_url", return_value="https://accounts.google.test/auth")
+    def test_admin_user_connect_gmail_redirects_to_google(self, build_authorization_url):
+        admin_user = get_user_model().objects.create_superuser(username="admin", email="admin@example.com", password="secret")
+        target_user = get_user_model().objects.create_user(username=self.account_email, email=self.account_email, password="secret")
+        self.client.force_login(admin_user)
+
+        response = self.client.get(reverse("admin:auth_user_connect_gmail", args=[target_user.pk]))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "https://accounts.google.test/auth")
+        build_authorization_url.assert_called_once()
+
+    def test_admin_user_connect_gmail_requires_staff_authentication(self):
+        target_user = get_user_model().objects.create_user(username=self.account_email, email=self.account_email, password="secret")
+
+        response = self.client.get(reverse("admin:auth_user_connect_gmail", args=[target_user.pk]))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/admin/login/", response["Location"])
+
     def test_gmail_account_status_returns_disconnected_contract(self):
         response = self.client.get(reverse("mailops:api_gmail_account_status"), **self.auth_headers())
 

--- a/blocklist-admin/mailops/urls.py
+++ b/blocklist-admin/mailops/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path("api/external-accounts/gmail/connect/complete", api.GmailConnectCompleteView.as_view(), name="api_gmail_connect_complete"),
     path("api/external-accounts/gmail/disconnect", api.GmailDisconnectView.as_view(), name="api_gmail_disconnect"),
     path("api/external-accounts/gmail/sync", api.GmailSyncTriggerView.as_view(), name="api_gmail_sync"),
+    path("oauth/gmail/callback", api.GmailOAuthCallbackView.as_view(), name="gmail_oauth_callback"),
     path("api/mail/folders", api.FolderListView.as_view(), name="api_mail_folders"),
     path("api/mail/conversations", api.ConversationListView.as_view(), name="api_mail_conversations"),
     path("api/mail/unified-conversations", api.UnifiedConversationListView.as_view(), name="api_mail_unified_conversations"),


### PR DESCRIPTION
## Summary

- add a Django admin Connect Gmail link on concrete user records
- add a browser OAuth callback at /oauth/gmail/callback that stores the user-scoped Gmail credentials
- keep the browser consent tied to the matching Django user through signed, time-limited OAuth state
- reuse the same Gmail account upsert behavior for the existing API completion flow

## Validation

- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mailops mail_integration
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py check
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py makemigrations --check --dry-run
- git diff --check

## Notes

- The Gmail consent step must still be completed by the owner of the matching Gmail account.
- Google OAuth client settings must include the configured callback URI, for example /oauth/gmail/callback.
