### PR TITLE
[codex] Require Gmail permanent delete scope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,13 @@ BLOCKLIST_DB_PASSWORD=mailblocklist-dev
 # FCM push notification bridge. Keep real values only in local `.env`.
 MAIL_NOTIFY_HOOK_SECRET=replace-me
 DEVICE_REGISTRATION_SECRET=replace-me
+
+# Gmail import OAuth. The full-mail scope is required for permanent source
+# deletion after a message has been safely appended and committed locally.
+GMAIL_IMPORT_GOOGLE_CLIENT_ID=replace-me.apps.googleusercontent.com
+GMAIL_IMPORT_GOOGLE_CLIENT_SECRET=replace-me
+GMAIL_IMPORT_OAUTH_REDIRECT_URI=https://mailadmin.example.com/oauth/gmail/callback
+GMAIL_IMPORT_OAUTH_SCOPES=https://mail.google.com/,https://www.googleapis.com/auth/gmail.modify
+GMAIL_IMPORT_SYNC_INTERVAL_SECONDS=600
+GMAIL_IMPORT_SYNC_LIMIT=100
+GMAIL_IMPORT_SYNC_MAX_ACCOUNTS=20

--- a/blocklist-admin/mail_integration/gmail_client.py
+++ b/blocklist-admin/mail_integration/gmail_client.py
@@ -11,6 +11,7 @@ from .exceptions import MailAuthError, MailConnectionError, MailProtocolError
 
 
 GMAIL_USER_ID = "me"
+GMAIL_PERMANENT_DELETE_SCOPE = "https://mail.google.com/"
 DEFAULT_RETRY_STATUSES = {429, 500, 502, 503, 504}
 
 
@@ -200,9 +201,7 @@ def exchange_code_for_refresh_token(code, oauth_config=None):
     try:
         flow.fetch_token(code=str(code).strip())
     except Exception as exc:
-        if _is_google_auth_error(exc):
-            raise MailAuthError("Gmail OAuth token exchange failed") from exc
-        raise
+        raise MailAuthError("Gmail OAuth token exchange failed") from exc
     refresh_token = getattr(flow.credentials, "refresh_token", "")
     if not refresh_token:
         raise MailAuthError("Gmail OAuth token exchange did not return a refresh token")

--- a/blocklist-admin/mail_integration/tests.py
+++ b/blocklist-admin/mail_integration/tests.py
@@ -80,14 +80,14 @@ class GmailClientTests(SimpleTestCase):
         GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
         GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
         GMAIL_IMPORT_OAUTH_REDIRECT_URI="urn:ietf:wg:oauth:2.0:oob",
-        GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",),
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://mail.google.com/",),
     )
     def test_oauth_config_reads_settings(self):
         config = oauth_config_from_settings()
 
         self.assertEqual(config.client_id, "client-id")
         self.assertEqual(config.client_secret, "client-secret")
-        self.assertEqual(config.scopes, ("https://www.googleapis.com/auth/gmail.modify",))
+        self.assertEqual(config.scopes, ("https://mail.google.com/",))
 
     def test_fetch_raw_message_decodes_payload_and_metadata(self):
         raw_bytes = b"Message-ID: <gmail-msg@example.com>\r\nSubject: Hi\r\n\r\nBody"

--- a/blocklist-admin/mailadmin_project/settings.py
+++ b/blocklist-admin/mailadmin_project/settings.py
@@ -127,7 +127,7 @@ GMAIL_IMPORT_OAUTH_SCOPES = tuple(
     scope.strip()
     for scope in os.environ.get(
         "GMAIL_IMPORT_OAUTH_SCOPES",
-        "https://www.googleapis.com/auth/gmail.modify",
+        "https://mail.google.com/,https://www.googleapis.com/auth/gmail.modify",
     ).split(",")
     if scope.strip()
 )

--- a/blocklist-admin/mailops/gmail_import.py
+++ b/blocklist-admin/mailops/gmail_import.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
-from mail_integration.gmail_client import GmailClient, GmailMessageRef
+from mail_integration.gmail_client import GMAIL_PERMANENT_DELETE_SCOPE, GmailClient, GmailMessageRef
 from mail_integration.imap_client import ImapClient
 from mail_integration.schemas import MailboxCredentials
 from mail_integration.exceptions import MailConnectionError, MailProtocolError
@@ -309,6 +310,8 @@ class GmailImportService:
         any_committed = False
         max_history_id = ""
         cleanup_enabled = bool(import_account.delete_after_import and not no_delete)
+        if cleanup_enabled:
+            _require_permanent_delete_scope()
 
         with self.imap_client_factory() as imap_client:
             imap_client.login(target_credentials)
@@ -522,6 +525,15 @@ def _historical_query(since):
     if since:
         query = f"{query} after:{since}"
     return query
+
+
+def _require_permanent_delete_scope():
+    configured_scopes = set(getattr(settings, "GMAIL_IMPORT_OAUTH_SCOPES", ()))
+    if GMAIL_PERMANENT_DELETE_SCOPE not in configured_scopes:
+        raise GmailImportError(
+            "Gmail permanent cleanup requires GMAIL_IMPORT_OAUTH_SCOPES to include "
+            f"{GMAIL_PERMANENT_DELETE_SCOPE}. Reconnect the Gmail account after changing the scope."
+        )
 
 
 def _target_folder(label_ids, sent_folder):

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -1107,6 +1107,7 @@ class MailApiTests(TestCase):
                 imap_client_factory=lambda: FakeImapClient(),
             ).run_historical_import_for_user(owner, limit=10)
 
+    @override_settings(GMAIL_IMPORT_OAUTH_SCOPES=("https://mail.google.com/",))
     def test_gmail_historical_import_deletes_only_after_commit_when_enabled(self):
         create_mailbox_token(self.account_email, self.password)
         account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
@@ -1140,6 +1141,7 @@ class MailApiTests(TestCase):
         self.assertEqual(message.cleanup_status, GmailImportMessage.STATUS_SUCCESS)
         self.assertEqual(message.target_folder, "Sent")
 
+    @override_settings(GMAIL_IMPORT_OAUTH_SCOPES=("https://mail.google.com/",))
     def test_gmail_historical_import_does_not_delete_when_append_fails(self):
         create_mailbox_token(self.account_email, self.password)
         account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
@@ -1175,6 +1177,26 @@ class MailApiTests(TestCase):
         self.assertEqual(message.append_status, GmailImportMessage.STATUS_FAILED)
         self.assertIsNone(message.committed_at)
 
+    @override_settings(GMAIL_IMPORT_OAUTH_SCOPES=("https://www.googleapis.com/auth/gmail.modify",))
+    def test_gmail_cleanup_requires_permanent_delete_scope(self):
+        create_mailbox_token(self.account_email, self.password)
+        account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+
+        with self.assertRaisesRegex(GmailImportError, "Gmail permanent cleanup requires"):
+            GmailImportService(
+                gmail_client_factory=lambda refresh_token: FakeGmailClient(refs=(GmailMessageRef(gmail_message_id="gmail-1"),)),
+                imap_client_factory=lambda: FakeImapClient(),
+            ).run_historical_import("source@gmail.com", self.account_email, limit=10)
+
+        self.assertFalse(GmailImportMessage.objects.exists())
+        run = GmailImportRun.objects.get(import_account=account)
+        self.assertEqual(run.status, GmailImportRun.STATUS_FAILED)
+        account.refresh_from_db()
+        self.assertIn("https://mail.google.com/", account.last_error)
+
+    @override_settings(GMAIL_IMPORT_OAUTH_SCOPES=("https://mail.google.com/",))
     def test_gmail_historical_import_recovers_appended_record_without_duplicate_append(self):
         create_mailbox_token(self.account_email, self.password)
         account = GmailImportAccount(gmail_email="source@gmail.com", target_mailbox_email=self.account_email, delete_after_import=True)

--- a/docs/gmail-import.md
+++ b/docs/gmail-import.md
@@ -19,6 +19,9 @@ The importer remains conservative:
 - Gmail cleanup is disabled by default.
 - When cleanup is enabled, Gmail deletion happens only after committed import
   state.
+- Permanent Gmail cleanup uses the Gmail API permanent delete operation, not
+  trash or archive semantics, and requires the `https://mail.google.com/`
+  OAuth scope.
 
 ## Scope
 
@@ -97,13 +100,19 @@ docker compose exec -T mailadmin python manage.py shell -c \
 ## Google OAuth Setup
 
 Create a Google OAuth client for the mailadmin app. The redirect URI must be the
-URI used by the client/operator flow that receives Google's `code` and `state`
-and then posts them to the `connect/complete` API endpoint. The backend currently
-does not expose a browser callback page by itself.
-
-The importer uses the Gmail modify scope:
+URI used by the browser callback that receives Google's `code` and `state`:
 
 ```text
+https://mailadmin.example.com/oauth/gmail/callback
+```
+
+The importer requests the Gmail full-mail scope so cleanup can permanently
+delete Gmail source messages after committed import. It also keeps the
+`gmail.modify` scope in the request for compatibility with accounts that were
+previously connected before permanent cleanup was enabled:
+
+```text
+https://mail.google.com/
 https://www.googleapis.com/auth/gmail.modify
 ```
 
@@ -113,7 +122,7 @@ Set these values in the local `.env`:
 GMAIL_IMPORT_GOOGLE_CLIENT_ID=google-client-id
 GMAIL_IMPORT_GOOGLE_CLIENT_SECRET=google-client-secret
 GMAIL_IMPORT_OAUTH_REDIRECT_URI=https://app.example.com/oauth/gmail/callback
-GMAIL_IMPORT_OAUTH_SCOPES=https://www.googleapis.com/auth/gmail.modify
+GMAIL_IMPORT_OAUTH_SCOPES=https://mail.google.com/,https://www.googleapis.com/auth/gmail.modify
 GMAIL_IMPORT_SYNC_INTERVAL_SECONDS=600
 GMAIL_IMPORT_SYNC_LIMIT=100
 GMAIL_IMPORT_SYNC_MAX_ACCOUNTS=20
@@ -268,8 +277,9 @@ account.delete_after_import = True
 account.save(update_fields=["delete_after_import", "updated_at"])
 ```
 
-Run another bounded sync without `no_delete`. Gmail source messages are deleted
-only after the message reaches committed import state:
+Run another bounded sync without `no_delete`. Gmail source messages are eligible
+for cleanup only when the import record is in `committed` state and has not
+already been marked `cleaned`:
 
 ```bash
 curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/sync" \
@@ -279,6 +289,8 @@ curl -sS -X POST "https://${MAILADMIN_HOST}/api/external-accounts/gmail/sync" \
 ```
 
 Use `"no_delete": true` any time you want to override cleanup for one run.
+Do not enable periodic or looped cleanup until a bounded manual cleanup batch
+succeeds with zero failures.
 
 ## Incremental Sync
 
@@ -458,6 +470,8 @@ Cleanup failed:
 - messages remain in committed state with `cleanup_status=failed`
 - rerun with cleanup enabled to retry Gmail deletion
 - use `"no_delete": true` to pause cleanup while investigating
+- verify `GMAIL_IMPORT_OAUTH_SCOPES=https://mail.google.com/` and reconnect the
+  Gmail account if cleanup fails with `permission denied`
 
 Logs:
 


### PR DESCRIPTION
## Summary

- require the full Gmail `https://mail.google.com/` scope for permanent source cleanup
- keep `gmail.modify` in the requested OAuth scope list for reconnect compatibility with existing grants
- fail Gmail cleanup early with an actionable error when permanent-delete scope is missing
- update docs and example env for permanent delete cleanup after committed import

## Validation

- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mailops mail_integration
- docker compose exec -T mailadmin python manage.py check
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py makemigrations --check --dry-run
- git diff --check

## Production smoke

- reconnected `avrcanus@gmail.com` with `https://mail.google.com/` plus `gmail.modify` scopes
- cleanup batches completed successfully: limit 50, 100, 500, and 1000/114 final scan all with `failed=0`
- mailbox contains 765 imported messages with no duplicate Gmail IDs
