### PR TITLE
[codex] Exclude Gmail from local mail domains

### DIFF
--- a/docker-data/dms/config/postfix-main.cf
+++ b/docker-data/dms/config/postfix-main.cf
@@ -1,2 +1,3 @@
 inet_protocols = ipv4
+virtual_mailbox_domains = dalekopro.hr finestar.hr qubitmdm.online uzorita.hr vitalgroupsa.com
 dms_smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, check_sender_access texthash:/tmp/docker-mailserver/postfix-sender-blocklist, reject_unknown_sender_domain


### PR DESCRIPTION
## Summary

- explicitly restrict Postfix virtual mailbox domains to domains hosted by this mailserver
- prevent `gmail.com` from being treated as local when a Gmail-backed import mailbox exists
- fix outbound delivery to external Gmail recipients such as `dalekopro@gmail.com`

## Validation

- `postconf -n` shows `virtual_mailbox_domains = dalekopro.hr finestar.hr qubitmdm.online uzorita.hr vitalgroupsa.com`
- `postfix reload` applied the runtime config
- Postfix verification routed `dalekopro@gmail.com` to `gmail-smtp-in.l.google.com` with `250 2.1.5 OK`
- mail queue is empty
