### PR TITLE
[codex] Send Gmail-backed mail through Gmail API

### DIFF
--- a/blocklist-admin/mail_integration/gmail_client.py
+++ b/blocklist-admin/mail_integration/gmail_client.py
@@ -147,6 +147,19 @@ class GmailClient:
         request = self.service.users().messages().delete(userId=GMAIL_USER_ID, id=gmail_message_id)
         self._execute(request, f"Gmail message delete failed for {gmail_message_id}")
 
+    def send_raw_message(self, raw_bytes):
+        raw_payload = base64.urlsafe_b64encode(raw_bytes).decode("ascii").rstrip("=")
+        request = self.service.users().messages().send(userId=GMAIL_USER_ID, body={"raw": raw_payload})
+        payload = self._execute(request, "Gmail message send failed")
+        gmail_message_id = str(payload.get("id", "") or "")
+        if not gmail_message_id:
+            raise MailProtocolError("Gmail send response did not include a message id")
+        return GmailMessageRef(
+            gmail_message_id=gmail_message_id,
+            gmail_thread_id=str(payload.get("threadId", "") or ""),
+            label_ids=tuple(str(label) for label in payload.get("labelIds", ()) if label),
+        )
+
     def get_profile_email(self):
         request = self.service.users().getProfile(userId=GMAIL_USER_ID)
         payload = self._execute(request, "Gmail profile fetch failed")

--- a/blocklist-admin/mail_integration/mailbox_service.py
+++ b/blocklist-admin/mail_integration/mailbox_service.py
@@ -81,16 +81,20 @@ class MailboxService:
             return client.restore_messages_from_trash(folder=folder, target_folder=target_folder, uids=uids)
 
     def send_mail(self, credentials, request):
-        request = self._resolve_forwarded_attachments(credentials, request)
-        _validate_attachment_limits(request.attachments)
+        request = self.prepare_send_request(credentials, request)
         with self.smtp_client_factory() as client:
             client.login(credentials)
             message_id = client.send_mail(credentials, request)
             sent_message = getattr(client, "last_sent_message", None)
-        self._append_sent_copy(credentials, sent_message)
+        self.append_sent_copy(credentials, sent_message)
         return message_id
 
-    def _append_sent_copy(self, credentials, sent_message):
+    def prepare_send_request(self, credentials, request):
+        request = self._resolve_forwarded_attachments(credentials, request)
+        _validate_attachment_limits(request.attachments)
+        return request
+
+    def append_sent_copy(self, credentials, sent_message):
         if not isinstance(sent_message, EmailMessage):
             return
         try:

--- a/blocklist-admin/mail_integration/smtp_client.py
+++ b/blocklist-admin/mail_integration/smtp_client.py
@@ -85,7 +85,7 @@ class SmtpClient:
         return self.connection
 
 
-def build_email_message(from_email, request: SendMailRequest):
+def build_email_message(from_email, request: SendMailRequest, include_bcc=False):
     if not request.to:
         raise ValueError("At least one recipient is required")
     if not request.text_body and not request.html_body:
@@ -96,6 +96,8 @@ def build_email_message(from_email, request: SendMailRequest):
     message["To"] = ", ".join(request.to)
     if request.cc:
         message["Cc"] = ", ".join(request.cc)
+    if include_bcc and request.bcc:
+        message["Bcc"] = ", ".join(request.bcc)
     if request.reply_to:
         message["Reply-To"] = request.reply_to
     if request.in_reply_to:

--- a/blocklist-admin/mail_integration/tests.py
+++ b/blocklist-admin/mail_integration/tests.py
@@ -56,7 +56,7 @@ def _http_error(status):
     return _FakeHttpError(status)
 
 
-def _gmail_service(list_payload=None, get_payload=None, history_payload=None, delete_payload=None, profile_payload=None):
+def _gmail_service(list_payload=None, get_payload=None, history_payload=None, delete_payload=None, profile_payload=None, send_payload=None):
     service = Mock()
     users_api = Mock()
     messages_api = Mock()
@@ -70,6 +70,7 @@ def _gmail_service(list_payload=None, get_payload=None, history_payload=None, de
     messages_api.list.return_value = _FakeRequest(list_payload or {})
     messages_api.get.return_value = _FakeRequest(get_payload or {})
     messages_api.delete.return_value = _FakeRequest(delete_payload or {})
+    messages_api.send.return_value = _FakeRequest(send_payload or {})
     history_api.list.return_value = _FakeRequest(history_payload or {})
     users_api.getProfile.return_value = _FakeRequest(profile_payload or {})
     return service
@@ -143,6 +144,19 @@ class GmailClientTests(SimpleTestCase):
         GmailClient(refresh_token="refresh", service=service).delete_message("msg-1")
 
         service.users_api.messages_api.delete.assert_called_once_with(userId="me", id="msg-1")
+
+    def test_send_raw_message_encodes_rfc822_payload(self):
+        service = _gmail_service(send_payload={"id": "gmail-sent-1", "threadId": "thread-1", "labelIds": ["SENT"]})
+
+        result = GmailClient(refresh_token="refresh", service=service).send_raw_message(b"From: sender@example.com\r\n\r\nBody")
+
+        service.users_api.messages_api.send.assert_called_once()
+        kwargs = service.users_api.messages_api.send.call_args.kwargs
+        self.assertEqual(kwargs["userId"], "me")
+        self.assertEqual(base64.urlsafe_b64decode(kwargs["body"]["raw"] + "=="), b"From: sender@example.com\r\n\r\nBody")
+        self.assertEqual(result.gmail_message_id, "gmail-sent-1")
+        self.assertEqual(result.gmail_thread_id, "thread-1")
+        self.assertEqual(result.label_ids, ("SENT",))
 
     def test_get_profile_email_reads_authenticated_gmail_identity(self):
         service = _gmail_service(profile_payload={"emailAddress": " USER@Example.COM "})

--- a/blocklist-admin/mailops/api.py
+++ b/blocklist-admin/mailops/api.py
@@ -78,6 +78,7 @@ from mail_integration.gmail_client import (
 )
 
 from .gmail_import import GmailImportError, GmailImportService
+from .gmail_send import GmailOutboundSendService
 from .models import DeviceRegistration, GmailImportAccount, MailAccountIndex, MailboxTokenCredential
 from .services import send_mail_notification
 
@@ -1279,8 +1280,12 @@ class SendMailView(APIView):
             attachments=attachments,
             forward_source_message=forward_source,
         )
+        mailbox_service = MailboxService()
         try:
-            message_id = MailboxService().send_mail(credentials, send_request)
+            gmail_sender = GmailOutboundSendService(mailbox_service=mailbox_service)
+            message_id = gmail_sender.send_mail(request.user, credentials, send_request)
+            if message_id is None:
+                message_id = mailbox_service.send_mail(credentials, send_request)
         except MailForwardAttachmentNotVisibleError as exc:
             return Response({"error": "forward_attachment_not_visible", "detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         except MailForwardAttachmentNotFoundError as exc:

--- a/blocklist-admin/mailops/gmail_send.py
+++ b/blocklist-admin/mailops/gmail_send.py
@@ -1,0 +1,96 @@
+from email import policy as email_policy
+
+from django.utils import timezone
+
+from mail_integration.exceptions import MailProtocolError
+from mail_integration.gmail_client import GmailClient, oauth_config_from_settings
+from mail_integration.mailbox_service import MailboxService
+from mail_integration.smtp_client import build_email_message
+
+from .models import GmailImportAccount, GmailImportMessage
+
+
+class GmailOutboundSendService:
+    def __init__(self, mailbox_service=None, gmail_client_factory=None):
+        self.mailbox_service = mailbox_service or MailboxService()
+        self.gmail_client_factory = gmail_client_factory or (lambda account: GmailClient(account.get_refresh_token(), oauth_config=oauth_config_from_settings()))
+
+    def can_send_for(self, user, mailbox_email):
+        return self._account_for(user, mailbox_email) is not None
+
+    def send_mail(self, user, credentials, request):
+        account = self._account_for(user, credentials.email)
+        if account is None:
+            return None
+
+        request = self.mailbox_service.prepare_send_request(credentials, request)
+        try:
+            message = build_email_message(credentials.email, request, include_bcc=True)
+        except (TypeError, ValueError, UnicodeError) as exc:
+            raise MailProtocolError(f"Could not build Gmail message: {exc}") from exc
+
+        raw_bytes = message.as_bytes(policy=email_policy.SMTP)
+        gmail_client = self.gmail_client_factory(account)
+        gmail_ref = gmail_client.send_raw_message(raw_bytes)
+        if "Bcc" in message:
+            del message["Bcc"]
+        self.mailbox_service.append_sent_copy(credentials, message)
+        self._commit_sent_record(account, gmail_ref, message)
+        if account.delete_after_import:
+            self._clean_sent_source(account, gmail_ref.gmail_message_id, gmail_client)
+        return message["Message-ID"]
+
+    def _account_for(self, user, mailbox_email):
+        if not user or not getattr(user, "is_authenticated", False):
+            return None
+        return (
+            GmailImportAccount.objects.filter(user=user, target_mailbox_email=(mailbox_email or "").strip().lower())
+            .select_related("user")
+            .first()
+        )
+
+    def _commit_sent_record(self, account, gmail_ref, message):
+        message_id = str(message.get("Message-ID", "") or "")
+        now = timezone.now()
+        record, _ = GmailImportMessage.objects.get_or_create(
+            import_account=account,
+            gmail_message_id=gmail_ref.gmail_message_id,
+            defaults={"fetched_at": now},
+        )
+        record.gmail_thread_id = gmail_ref.gmail_thread_id
+        record.rfc_message_id = message_id
+        record.target_folder = "Sent"
+        record.state = GmailImportMessage.STATE_COMMITTED
+        record.append_status = GmailImportMessage.STATUS_SUCCESS
+        record.appended_at = record.appended_at or now
+        record.committed_at = record.committed_at or now
+        record.error = ""
+        record.save(
+            update_fields=[
+                "gmail_thread_id",
+                "rfc_message_id",
+                "target_folder",
+                "state",
+                "append_status",
+                "appended_at",
+                "committed_at",
+                "error",
+                "updated_at",
+            ]
+        )
+
+    def _clean_sent_source(self, account, gmail_message_id, gmail_client):
+        record = GmailImportMessage.objects.get(import_account=account, gmail_message_id=gmail_message_id)
+        try:
+            gmail_client.delete_message(gmail_message_id)
+        except Exception as exc:
+            record.state = GmailImportMessage.STATE_COMMITTED
+            record.cleanup_status = GmailImportMessage.STATUS_FAILED
+            record.error = str(exc)[:2000]
+            record.save(update_fields=["state", "cleanup_status", "error", "updated_at"])
+            return
+        record.state = GmailImportMessage.STATE_CLEANED
+        record.cleanup_status = GmailImportMessage.STATUS_SUCCESS
+        record.cleaned_at = timezone.now()
+        record.error = ""
+        record.save(update_fields=["state", "cleanup_status", "cleaned_at", "error", "updated_at"])

--- a/blocklist-admin/mailops/tests.py
+++ b/blocklist-admin/mailops/tests.py
@@ -2745,6 +2745,56 @@ class MailApiTests(TestCase):
         index.refresh_from_db()
         self.assertIsNone(index.last_indexed_at)
 
+    @override_settings(
+        GMAIL_IMPORT_GOOGLE_CLIENT_ID="client-id",
+        GMAIL_IMPORT_GOOGLE_CLIENT_SECRET="client-secret",
+        GMAIL_IMPORT_OAUTH_REDIRECT_URI="https://mailadmin.example.com/oauth/gmail/callback",
+        GMAIL_IMPORT_OAUTH_SCOPES=("https://mail.google.com/", "https://www.googleapis.com/auth/gmail.modify"),
+    )
+    @patch("mailops.gmail_send.GmailClient")
+    @patch("mailops.api.MailboxService")
+    def test_mail_send_for_connected_gmail_account_uses_gmail_api(self, service_class, gmail_client_class):
+        headers = self.auth_headers()
+        token = Token.objects.get(user__email=self.account_email)
+        account = GmailImportAccount(user=token.user, gmail_email=self.account_email, target_mailbox_email=self.account_email, delete_after_import=True)
+        account.set_refresh_token("refresh-secret")
+        account.save()
+        service = service_class.return_value
+        service.prepare_send_request.side_effect = lambda credentials, send_request: send_request
+        gmail_client = gmail_client_class.return_value
+        gmail_client.send_raw_message.return_value = GmailMessageRef(gmail_message_id="gmail-sent-1", gmail_thread_id="thread-1")
+
+        response = self.client.post(
+            reverse("mailops:api_mail_send"),
+            data={
+                "to": ["to@example.com"],
+                "bcc": ["hidden@example.com"],
+                "subject": "Via Gmail",
+                "text_body": "Body",
+                "from_display_name": "Sender",
+            },
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message_id"].startswith("<"), True)
+        service.send_mail.assert_not_called()
+        service.prepare_send_request.assert_called_once()
+        service.append_sent_copy.assert_called_once()
+        raw_message = gmail_client.send_raw_message.call_args.args[0]
+        self.assertIn(b"From: Sender <user@example.com>", raw_message)
+        self.assertIn(b"To: to@example.com", raw_message)
+        self.assertIn(b"Bcc: hidden@example.com", raw_message)
+        sent_copy = service.append_sent_copy.call_args.args[1]
+        self.assertNotIn("Bcc", sent_copy)
+        gmail_client.delete_message.assert_called_once_with("gmail-sent-1")
+        message = GmailImportMessage.objects.get(import_account=account, gmail_message_id="gmail-sent-1")
+        self.assertEqual(message.state, GmailImportMessage.STATE_CLEANED)
+        self.assertEqual(message.cleanup_status, GmailImportMessage.STATUS_SUCCESS)
+        self.assertEqual(message.target_folder, "Sent")
+        self.assertEqual(message.rfc_message_id, response.json()["message_id"])
+
     @patch("mailops.api.MailboxService")
     def test_mail_send_accepts_multipart_attachments(self, service_class):
         headers = self.auth_headers()

--- a/docs/gmail-import.md
+++ b/docs/gmail-import.md
@@ -8,7 +8,9 @@ The v1 model is intentionally strict:
 - the connected Gmail address must exactly match the Django user email
 - onboarding is admin-managed through Django admin
 - Gmail access is OAuth-only; admins must not enter or store Gmail passwords
-- mailbox read/send APIs continue to use the local mailserver mailbox
+- mailbox read APIs continue to use the local mailserver mailbox
+- send uses Gmail API for connected Gmail-backed mailboxes and local SMTP for
+  normal local-domain mailboxes
 
 The importer remains conservative:
 

--- a/docs/mailbox-api.md
+++ b/docs/mailbox-api.md
@@ -578,11 +578,13 @@ Request:
 }
 ```
 
-Recipient fields accept either plain addresses such as `recipient@example.com` or mailbox-formatted values such as `Recipient Name <recipient@example.com>`. The backend normalizes them to one email address per item before sending. `Bcc` recipients are used only in the SMTP envelope and are not exposed in email headers.
+Recipient fields accept either plain addresses such as `recipient@example.com` or mailbox-formatted values such as `Recipient Name <recipient@example.com>`. The backend normalizes them to one email address per item before sending. For SMTP-backed sends, `Bcc` recipients are used only in the SMTP envelope and are not exposed in email headers. For Gmail API-backed sends, `Bcc` is included only in the raw message sent to Google so Gmail can deliver those recipients; the local Sent copy removes the `Bcc` header.
 
 For reply and reply-all flows, clients should send `in_reply_to` and `references` from the source message headers when available. Use the source message's `message_id` as `in_reply_to`; build `references` from the source message's existing `references` plus the source `message_id`. The backend writes these values as `In-Reply-To` and `References` headers so later indexing can attach the Sent copy to the same thread.
 
-After SMTP delivery succeeds, the backend appends the exact generated MIME message to the resolved IMAP Sent folder with the `\Seen` flag and marks the existing mail index stale. The next unified conversation refresh can then see the Sent copy through live IMAP fallback while background indexing catches up. If SMTP succeeds but the Sent append fails, the API still returns `status: sent` and logs a warning to avoid duplicate sends from client retries.
+For normal local-domain mailboxes, delivery uses the configured SMTP server. For a connected Gmail-backed mailbox whose authenticated mailbox email matches the connected Gmail identity, delivery uses the Gmail API instead of local Postfix so `@gmail.com` senders satisfy Gmail SPF/DKIM/DMARC policy.
+
+After delivery succeeds, the backend appends the exact generated MIME message to the resolved IMAP Sent folder with the `\Seen` flag and marks the existing mail index stale. Gmail-backed sends also store a Gmail import/dedupe record for the sent Gmail message; when `delete_after_import=true`, the Gmail Sent source is permanently deleted after the local Sent append/commit record is written. If delivery succeeds but the Sent append fails, the API still returns `status: sent` and logs a warning to avoid duplicate sends from client retries.
 
 For attachments, send `multipart/form-data` to the same endpoint. Text fields keep the same names, and files use repeated `attachments` parts:
 


### PR DESCRIPTION
## Summary

- route connected Gmail-backed mailbox sends through Gmail API instead of local Postfix
- keep normal local-domain mailbox sends on the existing SMTP path
- append Gmail-backed sent messages to the local Sent folder and create Gmail import/dedupe records
- permanently clean the Gmail Sent source after local commit when `delete_after_import=true`
- include Bcc only in the raw Gmail API send payload and remove it from the local Sent copy

## Validation

- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py test mailops mail_integration
- docker compose exec -T mailadmin python manage.py check
- docker compose run --rm --no-deps -v /opt/stacks/mailserver/blocklist-admin:/app mailadmin python manage.py makemigrations --check --dry-run
- git diff --check
